### PR TITLE
KES Agent prerequisites

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -39,6 +39,7 @@ library
   import:            base, project-config
   hs-source-dirs:    src
   exposed-modules:
+    Cardano.Crypto.DirectSerialise
     Cardano.Crypto.DSIGN
     Cardano.Crypto.DSIGN.Class
     Cardano.Crypto.DSIGN.Ed25519

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -66,14 +67,17 @@ import Cardano.Crypto.Libsodium.MLockedSeed
 import Cardano.Crypto.PinnedSizedBytes
   ( PinnedSizedBytes
   , psbUseAsSizedPtr
+  , psbUseAsCPtrLen
   , psbToByteString
   , psbFromByteStringCheck
+  , psbCreate
   , psbCreateSized
   , psbCreateSizedResult
   )
 import Cardano.Crypto.Seed
 import Cardano.Crypto.Util (SignableRepresentation(..))
 import Cardano.Foreign
+import Cardano.Crypto.DirectSerialise
 
 
 
@@ -261,7 +265,7 @@ instance DSIGNMAlgorithm Ed25519DSIGN where
               stToIO $ do
                 cOrError $ unsafeIOToST $
                   c_crypto_sign_ed25519_sk_to_pk pkPtr skPtr
-          throwOnErrno "deriveVerKeyDSIGNM @Ed25519DSIGN" "c_crypto_sign_ed25519_sk_to_pk" maybeErrno
+          throwOnErrno "deriveVerKeyDSIGN @Ed25519DSIGN" "c_crypto_sign_ed25519_sk_to_pk" maybeErrno
           return psb
 
 
@@ -365,3 +369,52 @@ instance TypeError ('Text "CBOR encoding would violate mlocking guarantees")
 instance TypeError ('Text "CBOR decoding would violate mlocking guarantees")
   => FromCBOR (SignKeyDSIGNM Ed25519DSIGN) where
   fromCBOR = error "unsupported"
+
+instance ( MonadThrow m
+         , MonadST m
+         ) => DirectSerialise m (SignKeyDSIGNM Ed25519DSIGN) where
+  -- /Note:/ We only serialize the 32-byte seed, not the full 64-byte key. The
+  -- latter contains both the seed and the 32-byte verification key, which is
+  -- convenient, but redundant, since we can always reconstruct it from the
+  -- seed. This is also reflected in the 'SizeSignKeyDSIGNM', which equals
+  -- 'SeedSizeDSIGNM' == 32, rather than reporting the in-memory size of 64.
+  directSerialise push sk = do
+    bracket
+      (getSeedDSIGNM (Proxy @Ed25519DSIGN) sk)
+      mlockedSeedFinalize
+      (\seed -> mlockedSeedUseAsCPtr seed $ \ptr ->
+          push
+            (castPtr ptr)
+            (fromIntegral $ seedSizeDSIGN (Proxy @Ed25519DSIGN)))
+
+instance ( MonadThrow m
+         , MonadST m
+         ) => DirectDeserialise m (SignKeyDSIGNM Ed25519DSIGN) where
+  -- /Note:/ We only serialize the 32-byte seed, not the full 64-byte key. See
+  -- the DirectSerialise m instance above.
+  directDeserialise pull = do
+    bracket
+      mlockedSeedNew
+      mlockedSeedFinalize
+      (\seed -> do
+          mlockedSeedUseAsCPtr seed $ \ptr -> do
+            pull
+              (castPtr ptr)
+              (fromIntegral $ seedSizeDSIGN (Proxy @Ed25519DSIGN))
+          genKeyDSIGNM seed
+      )
+
+instance MonadST m => DirectSerialise m (VerKeyDSIGN Ed25519DSIGN) where
+  directSerialise push (VerKeyEd25519DSIGN psb) = do
+    psbUseAsCPtrLen psb $ \ptr _ ->
+      push
+        (castPtr ptr)
+        (fromIntegral $ sizeVerKeyDSIGN (Proxy @Ed25519DSIGN))
+
+instance MonadST m => DirectDeserialise m (VerKeyDSIGN Ed25519DSIGN) where
+  directDeserialise pull = do
+    psb <- psbCreate $ \ptr ->
+      pull
+        (castPtr ptr)
+        (fromIntegral $ sizeVerKeyDSIGN (Proxy @Ed25519DSIGN))
+    return $! VerKeyEd25519DSIGN $! psb

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -370,9 +370,7 @@ instance TypeError ('Text "CBOR decoding would violate mlocking guarantees")
   => FromCBOR (SignKeyDSIGNM Ed25519DSIGN) where
   fromCBOR = error "unsupported"
 
-instance ( MonadThrow m
-         , MonadST m
-         ) => DirectSerialise m (SignKeyDSIGNM Ed25519DSIGN) where
+instance DirectSerialise (SignKeyDSIGNM Ed25519DSIGN) where
   -- /Note:/ We only serialize the 32-byte seed, not the full 64-byte key. The
   -- latter contains both the seed and the 32-byte verification key, which is
   -- convenient, but redundant, since we can always reconstruct it from the
@@ -387,11 +385,9 @@ instance ( MonadThrow m
             (castPtr ptr)
             (fromIntegral $ seedSizeDSIGN (Proxy @Ed25519DSIGN)))
 
-instance ( MonadThrow m
-         , MonadST m
-         ) => DirectDeserialise m (SignKeyDSIGNM Ed25519DSIGN) where
+instance DirectDeserialise (SignKeyDSIGNM Ed25519DSIGN) where
   -- /Note:/ We only serialize the 32-byte seed, not the full 64-byte key. See
-  -- the DirectSerialise m instance above.
+  -- the DirectSerialise instance above.
   directDeserialise pull = do
     bracket
       mlockedSeedNew
@@ -404,14 +400,14 @@ instance ( MonadThrow m
           genKeyDSIGNM seed
       )
 
-instance MonadST m => DirectSerialise m (VerKeyDSIGN Ed25519DSIGN) where
+instance DirectSerialise (VerKeyDSIGN Ed25519DSIGN) where
   directSerialise push (VerKeyEd25519DSIGN psb) = do
     psbUseAsCPtrLen psb $ \ptr _ ->
       push
         (castPtr ptr)
         (fromIntegral $ sizeVerKeyDSIGN (Proxy @Ed25519DSIGN))
 
-instance MonadST m => DirectDeserialise m (VerKeyDSIGN Ed25519DSIGN) where
+instance DirectDeserialise (VerKeyDSIGN Ed25519DSIGN) where
   directDeserialise pull = do
     psb <- psbCreate $ \ptr ->
       pull

--- a/cardano-crypto-class/src/Cardano/Crypto/DirectSerialise.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DirectSerialise.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-
 -- | Direct (de-)serialisation to / from raw memory.
 --
 -- The purpose of the typeclasses in this module is to abstract over data
@@ -18,6 +16,8 @@ where
 
 import Foreign.Ptr
 import Foreign.C.Types
+import Control.Monad.Class.MonadThrow (MonadThrow)
+import Control.Monad.Class.MonadST (MonadST)
 
 -- | Direct deserialization from raw memory.
 --
@@ -27,8 +27,8 @@ import Foreign.C.Types
 -- non-contiguous blocks of memory.
 --
 -- The order in which memory blocks are visited matters.
-class DirectDeserialise m a where
-  directDeserialise :: (Ptr CChar -> CSize -> m ()) -> m a
+class DirectDeserialise a where
+  directDeserialise :: (MonadST m, MonadThrow m) => (Ptr CChar -> CSize -> m ()) -> m a
 
 -- | Direct serialization to raw memory.
 --
@@ -37,5 +37,5 @@ class DirectDeserialise m a where
 -- of memory, @f@ may be called multiple times, once for each block.
 --
 -- The order in which memory blocks are visited matters.
-class DirectSerialise m a where
-  directSerialise :: (Ptr CChar -> CSize -> m ()) -> a -> m ()
+class DirectSerialise a where
+  directSerialise :: (MonadST m, MonadThrow m) => (Ptr CChar -> CSize -> m ()) -> a -> m ()

--- a/cardano-crypto-class/src/Cardano/Crypto/DirectSerialise.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DirectSerialise.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+-- | Direct (de-)serialisation to / from raw memory.
+--
+-- The purpose of the typeclasses in this module is to abstract over data
+-- structures that can expose the data they store as one or more raw 'Ptr's,
+-- without any additional memory copying or conversion to intermediate data
+-- structures.
+--
+-- This is useful for transmitting data like KES SignKeys over a socket
+-- connection: by accessing the memory directly and copying it into or out of
+-- a file descriptor, without going through an intermediate @ByteString@
+-- representation (or other data structure that resides in the GHC heap), we
+-- can more easily assure that the data is never written to disk, including
+-- swap, which is an important requirement for KES.
+module Cardano.Crypto.DirectSerialise
+where
+
+import Foreign.Ptr
+import Foreign.C.Types
+
+-- | Direct deserialization from raw memory.
+--
+-- @directDeserialise f@ should allocate a new value of type 'a', and
+-- call @f@ with a pointer to the raw memory to be filled. @f@ may be called
+-- multiple times, for data structures that store their data in multiple
+-- non-contiguous blocks of memory.
+--
+-- The order in which memory blocks are visited matters.
+class DirectDeserialise m a where
+  directDeserialise :: (Ptr CChar -> CSize -> m ()) -> m a
+
+-- | Direct serialization to raw memory.
+--
+-- @directSerialise f x@ should call @f@ to expose the raw memory underyling
+-- @x@. For data types that store their data in multiple non-contiguous blocks
+-- of memory, @f@ may be called multiple times, once for each block.
+--
+-- The order in which memory blocks are visited matters.
+class DirectSerialise m a where
+  directSerialise :: (Ptr CChar -> CSize -> m ()) -> a -> m ()

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -232,14 +232,14 @@ slice offset size = BS.take (fromIntegral size)
 -- Direct ser/deser
 --
 
-instance (DirectSerialise m (SignKeyDSIGNM d)) => DirectSerialise m (SignKeyKES (CompactSingleKES d)) where
+instance (DirectSerialise (SignKeyDSIGNM d)) => DirectSerialise (SignKeyKES (CompactSingleKES d)) where
   directSerialise push (SignKeyCompactSingleKES sk) = directSerialise push sk
 
-instance (Monad m, DirectDeserialise m (SignKeyDSIGNM d)) => DirectDeserialise m (SignKeyKES (CompactSingleKES d)) where
+instance (DirectDeserialise (SignKeyDSIGNM d)) => DirectDeserialise (SignKeyKES (CompactSingleKES d)) where
   directDeserialise pull = SignKeyCompactSingleKES <$!> directDeserialise pull
 
-instance (DirectSerialise m (VerKeyDSIGN d)) => DirectSerialise m (VerKeyKES (CompactSingleKES d)) where
+instance (DirectSerialise (VerKeyDSIGN d)) => DirectSerialise (VerKeyKES (CompactSingleKES d)) where
   directSerialise push (VerKeyCompactSingleKES sk) = directSerialise push sk
 
-instance (Monad m, DirectDeserialise m (VerKeyDSIGN d)) => DirectDeserialise m (VerKeyKES (CompactSingleKES d)) where
+instance (DirectDeserialise (VerKeyDSIGN d)) => DirectDeserialise (VerKeyKES (CompactSingleKES d)) where
   directDeserialise pull = VerKeyCompactSingleKES <$!> directDeserialise pull

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -60,7 +60,7 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash.Class
 import Cardano.Crypto.DSIGN.Class as DSIGN
 import Cardano.Crypto.KES.Class
-
+import Cardano.Crypto.DirectSerialise
 
 -- | A standard signature scheme is a forward-secure signature scheme with a
 -- single time period.
@@ -227,3 +227,19 @@ instance (DSIGNMAlgorithm d, KnownNat (SizeSigKES (CompactSingleKES d))) => From
 slice :: Word -> Word -> ByteString -> ByteString
 slice offset size = BS.take (fromIntegral size)
                   . BS.drop (fromIntegral offset)
+
+--
+-- Direct ser/deser
+--
+
+instance (DirectSerialise m (SignKeyDSIGNM d)) => DirectSerialise m (SignKeyKES (CompactSingleKES d)) where
+  directSerialise push (SignKeyCompactSingleKES sk) = directSerialise push sk
+
+instance (Monad m, DirectDeserialise m (SignKeyDSIGNM d)) => DirectDeserialise m (SignKeyKES (CompactSingleKES d)) where
+  directDeserialise pull = SignKeyCompactSingleKES <$!> directDeserialise pull
+
+instance (DirectSerialise m (VerKeyDSIGN d)) => DirectSerialise m (VerKeyKES (CompactSingleKES d)) where
+  directSerialise push (VerKeyCompactSingleKES sk) = directSerialise push sk
+
+instance (Monad m, DirectDeserialise m (VerKeyDSIGN d)) => DirectDeserialise m (VerKeyKES (CompactSingleKES d)) where
+  directDeserialise pull = VerKeyCompactSingleKES <$!> directDeserialise pull

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -514,5 +514,5 @@ instance (HashAlgorithm h)
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr -> do
       pull (castPtr ptr) len
-    let bs = BS.fromForeignPtr0 fptr len
+    let bs = BS.fromForeignPtr fptr 0 len
     maybe (error "Invalid hash") return $! VerKeyCompactSumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -514,5 +514,5 @@ instance (HashAlgorithm h)
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr -> do
       pull (castPtr ptr) len
-    let bs = BS.fromForeignPtr fptr 0 len
+    let bs = BS.fromForeignPtr (unsafeRawForeignPtr fptr) 0 len
     maybe (error "Invalid hash") return $! VerKeyCompactSumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -103,8 +103,6 @@ import           Cardano.Crypto.DirectSerialise
 
 import           Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import           Control.Monad.Trans (lift)
-import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadThrow
 import           Control.DeepSeq (NFData (..))
 import           GHC.TypeLits (KnownNat, type (+), type (*))
 import           Foreign.Ptr (castPtr)
@@ -474,11 +472,10 @@ instance ( OptimizedKESAlgorithm d
 -- Direct ser/deser
 --
 
-instance ( DirectSerialise m (SignKeyKES d)
-         , DirectSerialise m (VerKeyKES d)
-         , MonadST m
+instance ( DirectSerialise (SignKeyKES d)
+         , DirectSerialise (VerKeyKES d)
          , KESAlgorithm d
-         ) => DirectSerialise m (SignKeyKES (CompactSumKES h d)) where
+         ) => DirectSerialise (SignKeyKES (CompactSumKES h d)) where
   directSerialise push (SignKeyCompactSumKES sk r vk0 vk1) = do
     directSerialise push sk
     mlockedSeedUseAsCPtr r $ \ptr ->
@@ -486,11 +483,10 @@ instance ( DirectSerialise m (SignKeyKES d)
     directSerialise push vk0
     directSerialise push vk1
 
-instance ( DirectDeserialise m (SignKeyKES d)
-         , DirectDeserialise m (VerKeyKES d)
-         , MonadST m
+instance ( DirectDeserialise (SignKeyKES d)
+         , DirectDeserialise (VerKeyKES d)
          , KESAlgorithm d
-         ) => DirectDeserialise m (SignKeyKES (CompactSumKES h d)) where
+         ) => DirectDeserialise (SignKeyKES (CompactSumKES h d)) where
   directDeserialise pull = do
     sk <- directDeserialise pull
 
@@ -504,18 +500,17 @@ instance ( DirectDeserialise m (SignKeyKES d)
     return $! SignKeyCompactSumKES sk r vk0 vk1
 
 
-instance (MonadST m, MonadThrow m)
-         => DirectSerialise m (VerKeyKES (CompactSumKES h d)) where
+instance DirectSerialise (VerKeyKES (CompactSumKES h d)) where
   directSerialise push (VerKeyCompactSumKES h) =
     unpackByteStringCStringLen (hashToBytes h) $ \(ptr, len) ->
       push (castPtr ptr) (fromIntegral len)
 
-instance (MonadST m, MonadThrow m, MonadFail m, HashAlgorithm h)
-         => DirectDeserialise m (VerKeyKES (CompactSumKES h d)) where
+instance (HashAlgorithm h)
+         => DirectDeserialise (VerKeyKES (CompactSumKES h d)) where
   directDeserialise pull = do
     let len :: Num a => a
         len = fromIntegral $ sizeHash (Proxy @h)
     allocaBytes len $ \ptr -> do
       pull ptr len
       bs <- packByteStringCStringLen (ptr, len)
-      maybe (fail "Invalid hash") return $! VerKeyCompactSumKES <$!> hashFromBytes bs
+      maybe (error "Invalid hash") return $! VerKeyCompactSumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -87,6 +87,7 @@ module Cardano.Crypto.KES.CompactSum (
 import           Data.Proxy (Proxy(..))
 import           GHC.Generics (Generic)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Internal as BS
 import           Control.Monad (guard, (<$!>))
 import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 
@@ -510,7 +511,8 @@ instance (HashAlgorithm h)
   directDeserialise pull = do
     let len :: Num a => a
         len = fromIntegral $ sizeHash (Proxy @h)
-    allocaBytes len $ \ptr -> do
-      pull ptr len
-      bs <- packByteStringCStringLen (ptr, len)
-      maybe (error "Invalid hash") return $! VerKeyCompactSumKES <$!> hashFromBytes bs
+    fptr <- mallocForeignPtrBytes len
+    withForeignPtr fptr $ \ptr -> do
+      pull (castPtr ptr) len
+    let bs = BS.fromForeignPtr0 fptr len
+    maybe (error "Invalid hash") return $! VerKeyCompactSumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -215,7 +215,7 @@ instance (KnownNat t) => DirectDeserialise (SignKeyKES (MockKES t)) where
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr ->
         pull (castPtr ptr) (fromIntegral len)
-    let bs = BS.fromForeignPtr0 fptr len
+    let bs = BS.fromForeignPtr fptr 0 len
     maybe (error "directDeserialise @(SignKeyKES (MockKES t))") return $
         rawDeserialiseSignKeyMockKES bs
 
@@ -230,6 +230,6 @@ instance (KnownNat t) => DirectDeserialise (VerKeyKES (MockKES t)) where
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr ->
         pull (castPtr ptr) (fromIntegral len)
-    let bs = BS.fromForeignPtr0 fptr len
+    let bs = BS.fromForeignPtr fptr 0 len
     maybe (error "directDeserialise @(VerKeyKES (MockKES t))") return $
         rawDeserialiseVerKeyKES bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -37,7 +37,7 @@ import Cardano.Crypto.KES.Class
 import Cardano.Crypto.Util
 import Cardano.Crypto.Libsodium.MLockedSeed
 import Cardano.Crypto.Libsodium
-  ( mlsbAsByteString
+  ( mlsbToByteString
   )
 import Cardano.Crypto.Libsodium.Memory
   ( unpackByteStringCStringLen
@@ -159,7 +159,8 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     --
 
     genKeyKESWith _allocator seed = do
-        let vk = VerKeyMockKES (runMonadRandomWithSeed (mkSeedFromBytes . mlsbAsByteString . mlockedSeedMLSB $ seed) getRandomWord64)
+        seedBS <- mlsbToByteString . mlockedSeedMLSB $ seed
+        let vk = VerKeyMockKES (runMonadRandomWithSeed (mkSeedFromBytes seedBS) getRandomWord64)
         return $! SignKeyMockKES vk 0
 
     forgetSignKeyKESWith _ = const $ return ()

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -41,6 +41,7 @@ import Cardano.Crypto.Libsodium
   )
 import Cardano.Crypto.Libsodium.Memory
   ( unpackByteStringCStringLen
+  , ForeignPtr (..)
   , mallocForeignPtrBytes
   , withForeignPtr
   )
@@ -215,7 +216,7 @@ instance (KnownNat t) => DirectDeserialise (SignKeyKES (MockKES t)) where
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr ->
         pull (castPtr ptr) (fromIntegral len)
-    let bs = BS.fromForeignPtr fptr 0 len
+    let bs = BS.fromForeignPtr (unsafeRawForeignPtr fptr) 0 len
     maybe (error "directDeserialise @(SignKeyKES (MockKES t))") return $
         rawDeserialiseSignKeyMockKES bs
 
@@ -230,6 +231,6 @@ instance (KnownNat t) => DirectDeserialise (VerKeyKES (MockKES t)) where
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr ->
         pull (castPtr ptr) (fromIntegral len)
-    let bs = BS.fromForeignPtr fptr 0 len
+    let bs = BS.fromForeignPtr (unsafeRawForeignPtr fptr) 0 len
     maybe (error "directDeserialise @(VerKeyKES (MockKES t))") return $
         rawDeserialiseVerKeyKES bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -26,8 +26,6 @@ import GHC.TypeNats (Nat, KnownNat, natVal)
 import NoThunks.Class (NoThunks)
 
 import Control.Exception (assert)
-import Control.Monad.Class.MonadST (MonadST)
-import Control.Monad.Class.MonadThrow (MonadThrow)
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
@@ -204,12 +202,12 @@ instance KnownNat t => ToCBOR (SigKES (MockKES t)) where
 instance KnownNat t => FromCBOR (SigKES (MockKES t)) where
   fromCBOR = decodeSigKES
 
-instance (MonadST m, MonadThrow m, KnownNat t) => DirectSerialise m (SignKeyKES (MockKES t)) where
+instance (KnownNat t) => DirectSerialise (SignKeyKES (MockKES t)) where
   directSerialise put sk = do
     let bs = rawSerialiseSignKeyMockKES sk
     unpackByteStringCStringLen bs $ \(cstr, len) -> put cstr (fromIntegral len)
 
-instance (MonadST m, MonadThrow m, KnownNat t) => DirectDeserialise m (SignKeyKES (MockKES t)) where
+instance (KnownNat t) => DirectDeserialise (SignKeyKES (MockKES t)) where
   directDeserialise pull = do
     let len = fromIntegral $ sizeSignKeyKES (Proxy @(MockKES t))
     bs <- allocaBytes len $ \cstr -> do
@@ -218,12 +216,12 @@ instance (MonadST m, MonadThrow m, KnownNat t) => DirectDeserialise m (SignKeyKE
     maybe (error "directDeserialise @(SignKeyKES (MockKES t))") return $
         rawDeserialiseSignKeyMockKES bs
 
-instance (MonadST m, MonadThrow m, KnownNat t) => DirectSerialise m (VerKeyKES (MockKES t)) where
+instance (KnownNat t) => DirectSerialise (VerKeyKES (MockKES t)) where
   directSerialise put sk = do
     let bs = rawSerialiseVerKeyKES sk
     unpackByteStringCStringLen bs $ \(cstr, len) -> put cstr (fromIntegral len)
 
-instance (MonadST m, MonadThrow m, KnownNat t) => DirectDeserialise m (VerKeyKES (MockKES t)) where
+instance (KnownNat t) => DirectDeserialise (VerKeyKES (MockKES t)) where
   directDeserialise pull = do
     let len = fromIntegral $ sizeVerKeyKES (Proxy @(MockKES t))
     bs <- allocaBytes len $ \cstr -> do

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -26,6 +26,8 @@ import GHC.TypeNats (Nat, KnownNat, natVal)
 import NoThunks.Class (NoThunks)
 
 import Control.Exception (assert)
+import Control.Monad.Class.MonadST (MonadST)
+import Control.Monad.Class.MonadThrow (MonadThrow)
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
@@ -37,6 +39,12 @@ import Cardano.Crypto.Libsodium.MLockedSeed
 import Cardano.Crypto.Libsodium
   ( mlsbAsByteString
   )
+import Cardano.Crypto.Libsodium.Memory
+  ( unpackByteStringCStringLen
+  , packByteStringCStringLen
+  , allocaBytes
+  )
+import Cardano.Crypto.DirectSerialise
 
 data MockKES (t :: Nat)
 
@@ -194,3 +202,31 @@ instance KnownNat t => ToCBOR (SigKES (MockKES t)) where
 
 instance KnownNat t => FromCBOR (SigKES (MockKES t)) where
   fromCBOR = decodeSigKES
+
+instance (MonadST m, MonadThrow m, KnownNat t) => DirectSerialise m (SignKeyKES (MockKES t)) where
+  directSerialise put sk = do
+    let bs = rawSerialiseSignKeyMockKES sk
+    unpackByteStringCStringLen bs $ \(cstr, len) -> put cstr (fromIntegral len)
+
+instance (MonadST m, MonadThrow m, KnownNat t) => DirectDeserialise m (SignKeyKES (MockKES t)) where
+  directDeserialise pull = do
+    let len = fromIntegral $ sizeSignKeyKES (Proxy @(MockKES t))
+    bs <- allocaBytes len $ \cstr -> do
+        pull cstr (fromIntegral len)
+        packByteStringCStringLen (cstr, len)
+    maybe (error "directDeserialise @(SignKeyKES (MockKES t))") return $
+        rawDeserialiseSignKeyMockKES bs
+
+instance (MonadST m, MonadThrow m, KnownNat t) => DirectSerialise m (VerKeyKES (MockKES t)) where
+  directSerialise put sk = do
+    let bs = rawSerialiseVerKeyKES sk
+    unpackByteStringCStringLen bs $ \(cstr, len) -> put cstr (fromIntegral len)
+
+instance (MonadST m, MonadThrow m, KnownNat t) => DirectDeserialise m (VerKeyKES (MockKES t)) where
+  directDeserialise pull = do
+    let len = fromIntegral $ sizeVerKeyKES (Proxy @(MockKES t))
+    bs <- allocaBytes len $ \cstr -> do
+        pull cstr (fromIntegral len)
+        packByteStringCStringLen (cstr, len)
+    maybe (error "directDeserialise @(VerKeyKES (MockKES t))") return $
+        rawDeserialiseVerKeyKES bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -250,21 +250,21 @@ instance (DSIGNMAlgorithm d
       => FromCBOR (SigKES (SimpleKES d t)) where
   fromCBOR = decodeSigKES
 
-instance (Monad m, DirectSerialise m (VerKeyDSIGN d)) => DirectSerialise m (VerKeyKES (SimpleKES d t)) where
+instance (DirectSerialise (VerKeyDSIGN d)) => DirectSerialise (VerKeyKES (SimpleKES d t)) where
   directSerialise push (VerKeySimpleKES vks) =
     mapM_ (directSerialise push) vks
 
-instance (Monad m, DirectDeserialise m (VerKeyDSIGN d), KnownNat t) => DirectDeserialise m (VerKeyKES (SimpleKES d t)) where
+instance (DirectDeserialise (VerKeyDSIGN d), KnownNat t) => DirectDeserialise (VerKeyKES (SimpleKES d t)) where
   directDeserialise pull = do
     let duration = fromIntegral (natVal (Proxy :: Proxy t))
     vks <- Vec.replicateM duration (directDeserialise pull)
     return $! VerKeySimpleKES $! vks
 
-instance (Monad m, DirectSerialise m (SignKeyDSIGNM d)) => DirectSerialise m (SignKeyKES (SimpleKES d t)) where
+instance (DirectSerialise (SignKeyDSIGNM d)) => DirectSerialise (SignKeyKES (SimpleKES d t)) where
   directSerialise push (SignKeySimpleKES sks) =
     mapM_ (directSerialise push) sks
 
-instance (Monad m, DirectDeserialise m (SignKeyDSIGNM d), KnownNat t) => DirectDeserialise m (SignKeyKES (SimpleKES d t)) where
+instance (DirectDeserialise (SignKeyDSIGNM d), KnownNat t) => DirectDeserialise (SignKeyKES (SimpleKES d t)) where
   directDeserialise pull = do
     let duration = fromIntegral (natVal (Proxy :: Proxy t))
     sks <- Vec.replicateM duration (directDeserialise pull)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -192,14 +192,14 @@ instance DSIGNMAlgorithm d => FromCBOR (SigKES (SingleKES d)) where
 -- Direct ser/deser
 --
 
-instance (DirectSerialise m (SignKeyDSIGNM d)) => DirectSerialise m (SignKeyKES (SingleKES d)) where
+instance (DirectSerialise (SignKeyDSIGNM d)) => DirectSerialise (SignKeyKES (SingleKES d)) where
   directSerialise push (SignKeySingleKES sk) = directSerialise push sk
 
-instance (Monad m, DirectDeserialise m (SignKeyDSIGNM d)) => DirectDeserialise m (SignKeyKES (SingleKES d)) where
+instance (DirectDeserialise (SignKeyDSIGNM d)) => DirectDeserialise (SignKeyKES (SingleKES d)) where
   directDeserialise pull = SignKeySingleKES <$!> directDeserialise pull
 
-instance (DirectSerialise m (VerKeyDSIGN d)) => DirectSerialise m (VerKeyKES (SingleKES d)) where
+instance (DirectSerialise (VerKeyDSIGN d)) => DirectSerialise (VerKeyKES (SingleKES d)) where
   directSerialise push (VerKeySingleKES sk) = directSerialise push sk
 
-instance (Monad m, DirectDeserialise m (VerKeyDSIGN d)) => DirectDeserialise m (VerKeyKES (SingleKES d)) where
+instance (DirectDeserialise (VerKeyDSIGN d)) => DirectDeserialise (VerKeyKES (SingleKES d)) where
   directDeserialise pull = VerKeySingleKES <$!> directDeserialise pull

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -50,7 +50,7 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash.Class
 import Cardano.Crypto.DSIGN.Class as DSIGN
 import Cardano.Crypto.KES.Class
-
+import Cardano.Crypto.DirectSerialise
 
 -- | A standard signature scheme is a forward-secure signature scheme with a
 -- single time period.
@@ -187,4 +187,19 @@ instance DSIGNMAlgorithm d => ToCBOR (SigKES (SingleKES d)) where
 
 instance DSIGNMAlgorithm d => FromCBOR (SigKES (SingleKES d)) where
   fromCBOR = decodeSigKES
-  {-# INLINE fromCBOR #-}
+
+--
+-- Direct ser/deser
+--
+
+instance (DirectSerialise m (SignKeyDSIGNM d)) => DirectSerialise m (SignKeyKES (SingleKES d)) where
+  directSerialise push (SignKeySingleKES sk) = directSerialise push sk
+
+instance (Monad m, DirectDeserialise m (SignKeyDSIGNM d)) => DirectDeserialise m (SignKeyKES (SingleKES d)) where
+  directDeserialise pull = SignKeySingleKES <$!> directDeserialise pull
+
+instance (DirectSerialise m (VerKeyDSIGN d)) => DirectSerialise m (VerKeyKES (SingleKES d)) where
+  directSerialise push (VerKeySingleKES sk) = directSerialise push sk
+
+instance (Monad m, DirectDeserialise m (VerKeyDSIGN d)) => DirectDeserialise m (VerKeyKES (SingleKES d)) where
+  directDeserialise pull = VerKeySingleKES <$!> directDeserialise pull

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -434,5 +434,5 @@ instance (HashAlgorithm h)
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr -> do
       pull (castPtr ptr) len
-    let bs = BS.fromForeignPtr0 fptr len
+    let bs = BS.fromForeignPtr fptr 0 len
     maybe (error "Invalid hash") return $! VerKeySumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -54,6 +54,7 @@ module Cardano.Crypto.KES.Sum (
 import           Data.Proxy (Proxy(..))
 import           GHC.Generics (Generic)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Internal as BS
 import           Control.Monad (guard, (<$!>))
 import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 
@@ -430,7 +431,8 @@ instance (HashAlgorithm h)
   directDeserialise pull = do
     let len :: Num a => a
         len = fromIntegral $ sizeHash (Proxy @h)
-    allocaBytes len $ \ptr -> do
-      pull ptr len
-      bs <- packByteStringCStringLen (ptr, len)
-      maybe (error "Invalid hash") return $! VerKeySumKES <$!> hashFromBytes bs
+    fptr <- mallocForeignPtrBytes len
+    withForeignPtr fptr $ \ptr -> do
+      pull (castPtr ptr) len
+    let bs = BS.fromForeignPtr0 fptr len
+    maybe (error "Invalid hash") return $! VerKeySumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -434,5 +434,5 @@ instance (HashAlgorithm h)
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr -> do
       pull (castPtr ptr) len
-    let bs = BS.fromForeignPtr fptr 0 len
+    let bs = BS.fromForeignPtr (unsafeRawForeignPtr fptr) 0 len
     maybe (error "Invalid hash") return $! VerKeySumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
@@ -29,6 +29,8 @@ module Cardano.Crypto.Libsodium.C (
     c_crypto_sign_ed25519_detached,
     c_crypto_sign_ed25519_verify_detached,
     c_crypto_sign_ed25519_sk_to_pk,
+    -- * RNG
+    c_sodium_randombytes_buf,
     -- * Helpers
     c_sodium_compare,
     -- * Constants
@@ -182,3 +184,6 @@ foreign import capi unsafe "sodium.h crypto_sign_ed25519_sk_to_pk" c_crypto_sign
 --
 -- <https://libsodium.gitbook.io/doc/helpers#comparing-large-numbers>
 foreign import capi unsafe "sodium.h sodium_compare" c_sodium_compare :: Ptr a -> Ptr a -> CSize -> IO Int
+
+-- | @void randombytes_buf(void * const buf, const size_t size);@
+foreign import capi unsafe "sodium/randombytes.h randombytes_buf" c_sodium_randombytes_buf :: Ptr a -> CSize -> IO ()

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
@@ -26,6 +26,7 @@ module Cardano.Crypto.Libsodium.Memory (
   allocaBytes,
 
   -- * 'ForeignPtr' operations, generalized to 'MonadST'
+  ForeignPtr (..),
   mallocForeignPtrBytes,
   withForeignPtr,
 

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
@@ -25,6 +25,10 @@ module Cardano.Crypto.Libsodium.Memory (
   copyMem,
   allocaBytes,
 
+  -- * 'ForeignPtr' operations, generalized to 'MonadST'
+  mallocForeignPtrBytes,
+  withForeignPtr,
+
   -- * ByteString memory access, generalized to 'MonadST'
   unpackByteStringCStringLen,
   packByteStringCStringLen,

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
@@ -26,6 +26,7 @@ module Cardano.Crypto.Libsodium.Memory (
   allocaBytes,
 
   -- * ByteString memory access, generalized to 'MonadST'
+  unpackByteStringCStringLen,
   packByteStringCStringLen,
 ) where
 

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
@@ -58,7 +58,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Coerce (coerce)
 import Data.Typeable
-import Data.Word (Word8)
 import Debug.Trace (traceShowM)
 import Foreign.C.Error (errnoToIOError, getErrno)
 import Foreign.C.String (CStringLen)
@@ -70,7 +69,7 @@ import Foreign.ForeignPtr (ForeignPtr)
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.Marshal.Utils (fillBytes)
 import Foreign.Ptr (Ptr, nullPtr, castPtr)
-import Foreign.Storable (Storable (peek), sizeOf, alignment, pokeByteOff)
+import Foreign.Storable (Storable (peek), sizeOf, alignment)
 import GHC.IO.Exception (ioException)
 import GHC.TypeLits (KnownNat, natVal)
 import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
@@ -220,10 +219,9 @@ allocaBytes size action = do
 unpackByteStringCStringLen :: (MonadThrow m, MonadST m) => ByteString -> (CStringLen -> m a) -> m a
 unpackByteStringCStringLen bs f = do
   let len = BS.length bs
-  allocaBytes (len + 1) $ \buf -> do
+  allocaBytes len $ \buf -> do
     unsafeIOToMonadST $ BS.unsafeUseAsCString bs $ \ptr -> do
       copyMem buf ptr (fromIntegral len)
-      pokeByteOff buf len (0 :: Word8)
     f (buf, len)
 
 packByteStringCStringLen :: MonadST m => CStringLen -> m ByteString

--- a/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
@@ -27,6 +27,7 @@ import Test.QuickCheck (
   forAllShow,
   forAllShrinkShow,
   ioProperty,
+  counterexample,
   )
 import Test.Tasty (TestTree, testGroup, adjustOption)
 import Test.Tasty.QuickCheck (testProperty, QuickCheckTests)
@@ -94,6 +95,7 @@ import Cardano.Crypto.DSIGN (
   )
 import Cardano.Binary (FromCBOR, ToCBOR)
 import Cardano.Crypto.PinnedSizedBytes (PinnedSizedBytes)
+import Cardano.Crypto.DirectSerialise
 import Test.Crypto.Util (
   Message,
   prop_raw_serialise,
@@ -111,6 +113,9 @@ import Test.Crypto.Util (
   showBadInputFor,
   Lock,
   withLock,
+  directSerialiseToBS,
+  directDeserialiseFromBS,
+  hexBS,
   )
 import Cardano.Crypto.Libsodium.MLockedSeed
 
@@ -362,6 +367,10 @@ testDSIGNMAlgorithm
                , FromCBOR (SigDSIGN v)
                , ContextDSIGN v ~ ()
                , Signable v Message
+               , DirectSerialise IO (SignKeyDSIGNM v)
+               , DirectDeserialise IO (SignKeyDSIGNM v)
+               , DirectSerialise IO (VerKeyDSIGN v)
+               , DirectDeserialise IO (VerKeyDSIGN v)
                )
   => Lock
   -> Proxy v
@@ -451,6 +460,36 @@ testDSIGNMAlgorithm lock _ n =
               sig :: SigDSIGN v <- signDSIGNM () msg sk
               return $ prop_cbor_direct_vs_class encodeSigDSIGN sig
         ]
+      , testGroup "DirectSerialise"
+        [ testProperty "VerKey" $
+            ioPropertyWithSK @v lock $ \sk -> do
+              vk :: VerKeyDSIGN v <- deriveVerKeyDSIGNM sk
+              serialized <- directSerialiseToBS (fromIntegral $ sizeVerKeyDSIGN (Proxy @v)) vk
+              vk' <- directDeserialiseFromBS serialized
+              return $ vk === vk'
+        , testProperty "SignKey" $
+            ioPropertyWithSK @v lock $ \sk -> do
+              serialized <- directSerialiseToBS (fromIntegral $ sizeSignKeyDSIGN (Proxy @v)) sk
+              sk' <- directDeserialiseFromBS serialized
+              equals <- sk ==! sk'
+              forgetSignKeyDSIGNM sk'
+              return $
+                counterexample ("Serialized: " ++ hexBS serialized ++ " (length: " ++ show (BS.length serialized) ++ ")") $
+                equals
+        ]
+      , testGroup "DirectSerialise matches raw"
+        [ testProperty "VerKey" $
+            ioPropertyWithSK @v lock $ \sk -> do
+              vk :: VerKeyDSIGN v <- deriveVerKeyDSIGNM sk
+              direct <- directSerialiseToBS (fromIntegral $ sizeVerKeyDSIGN (Proxy @v)) vk
+              let raw = rawSerialiseVerKeyDSIGN vk
+              return $ direct === raw
+        , testProperty "SignKey" $
+            ioPropertyWithSK @v lock $ \sk -> do
+              direct <- directSerialiseToBS (fromIntegral $ sizeSignKeyDSIGN (Proxy @v)) sk
+              raw <- rawSerialiseSignKeyDSIGNM sk
+              return $ direct === raw
+        ]
       ]
 
     , testGroup "verify"
@@ -477,6 +516,24 @@ testDSIGNMAlgorithm lock _ n =
           ioPropertyWithSK @v lock $ prop_no_thunks_IO . return
       , testProperty "Sig"     $ \(msg :: Message) ->
           ioPropertyWithSK @v lock $ prop_no_thunks_IO . signDSIGNM () msg
+      , testProperty "SignKey DirectSerialise" $
+          ioPropertyWithSK @v lock $ \sk -> do
+            direct <- directSerialiseToBS (fromIntegral $ sizeSignKeyDSIGN (Proxy @v)) sk
+            prop_no_thunks_IO (return $! direct)
+      , testProperty "SignKey DirectDeserialise" $
+          ioPropertyWithSK @v lock $ \sk -> do
+            direct <- directSerialiseToBS (fromIntegral $ sizeSignKeyDSIGN (Proxy @v)) sk
+            prop_no_thunks_IO (directDeserialiseFromBS @IO @(SignKeyDSIGNM v) $! direct)
+      , testProperty "VerKey DirectSerialise" $
+          ioPropertyWithSK @v lock $ \sk -> do
+            vk <- deriveVerKeyDSIGNM sk
+            direct <- directSerialiseToBS (fromIntegral $ sizeVerKeyDSIGN (Proxy @v)) vk
+            prop_no_thunks_IO (return $! direct)
+      , testProperty "VerKey DirectDeserialise" $
+          ioPropertyWithSK @v lock $ \sk -> do
+            vk <- deriveVerKeyDSIGNM sk
+            direct <- directSerialiseToBS (fromIntegral $ sizeVerKeyDSIGN (Proxy @v)) vk
+            prop_no_thunks_IO (directDeserialiseFromBS @IO @(VerKeyDSIGN v) $! direct)
       ]
     ]
 

--- a/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
@@ -367,10 +367,10 @@ testDSIGNMAlgorithm
                , FromCBOR (SigDSIGN v)
                , ContextDSIGN v ~ ()
                , Signable v Message
-               , DirectSerialise IO (SignKeyDSIGNM v)
-               , DirectDeserialise IO (SignKeyDSIGNM v)
-               , DirectSerialise IO (VerKeyDSIGN v)
-               , DirectDeserialise IO (VerKeyDSIGN v)
+               , DirectSerialise (SignKeyDSIGNM v)
+               , DirectDeserialise (SignKeyDSIGNM v)
+               , DirectSerialise (VerKeyDSIGN v)
+               , DirectDeserialise (VerKeyDSIGN v)
                )
   => Lock
   -> Proxy v

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -208,10 +208,10 @@ testKESAlgorithm
      , Signable v ~ SignableRepresentation
      , ContextKES v ~ ()
      , UnsoundKESAlgorithm v
-     , DirectSerialise IO (SignKeyKES v)
-     , DirectSerialise IO (VerKeyKES v)
-     , DirectDeserialise IO (SignKeyKES v)
-     , DirectDeserialise IO (VerKeyKES v)
+     , DirectSerialise (SignKeyKES v)
+     , DirectSerialise (VerKeyKES v)
+     , DirectDeserialise (SignKeyKES v)
+     , DirectDeserialise (VerKeyKES v)
      )
   => Lock
   -> String
@@ -766,7 +766,7 @@ withNullSK = bracket
 prop_noErasedBlocksInKey
   :: forall v.
      UnsoundKESAlgorithm v
-  => DirectSerialise IO (SignKeyKES v)
+  => DirectSerialise (SignKeyKES v)
   => Proxy v
   -> Property
 prop_noErasedBlocksInKey kesAlgorithm =

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -29,21 +29,29 @@ import Data.List (foldl')
 import qualified Data.ByteString as BS
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Foreign.Ptr (WordPtr)
+import Foreign.Ptr (WordPtr, plusPtr)
 import Data.IORef
-import GHC.TypeNats (KnownNat)
+import GHC.TypeNats (KnownNat, natVal)
 
-import Control.Tracer
+import Control.Concurrent.MVar (newMVar, takeMVar, putMVar)
+import Control.Monad (void, when)
+import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadThrow
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad (void)
+import Control.Tracer
 
 import Cardano.Crypto.DSIGN hiding (Signable)
 import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
+import Cardano.Crypto.DirectSerialise (DirectSerialise, directSerialise, DirectDeserialise)
 import Cardano.Crypto.Util (SignableRepresentation(..))
 import Cardano.Crypto.Libsodium
 import Cardano.Crypto.Libsodium.MLockedSeed
+import Cardano.Crypto.Libsodium.Memory
+  ( copyMem
+  , allocaBytes
+  , packByteStringCStringLen
+  )
 import Cardano.Crypto.PinnedSizedBytes
 
 import Test.QuickCheck
@@ -67,6 +75,8 @@ import Test.Crypto.Util (
   noExceptionsThrown,
   Lock,
   withLock,
+  directSerialiseToBS,
+  directDeserialiseFromBS,
   )
 import Test.Crypto.EqST
 import Test.Crypto.Instances (withMLockedSeedFromPSB)
@@ -198,6 +208,10 @@ testKESAlgorithm
      , Signable v ~ SignableRepresentation
      , ContextKES v ~ ()
      , UnsoundKESAlgorithm v
+     , DirectSerialise IO (SignKeyKES v)
+     , DirectSerialise IO (VerKeyKES v)
+     , DirectDeserialise IO (SignKeyKES v)
+     , DirectDeserialise IO (VerKeyKES v)
      )
   => Lock
   -> String
@@ -225,9 +239,32 @@ testKESAlgorithm lock n =
       , testProperty "Sig"     $ \seedPSB (msg :: Message) ->
           ioProperty $ withLock lock $ fmap conjoin $ withAllUpdatesKES @v seedPSB $ \t sk -> do
             prop_no_thunks_IO (signKES () t msg sk)
+
+      , testProperty "VerKey DirectSerialise" $
+          ioPropertyWithSK @v lock $ \sk -> do
+            vk :: VerKeyKES v <- deriveVerKeyKES sk
+            direct <- directSerialiseToBS (fromIntegral $ sizeVerKeyKES (Proxy @v)) vk
+            prop_no_thunks_IO (return $! direct)
+      , testProperty "SignKey DirectSerialise" $
+          ioPropertyWithSK @v lock $ \sk -> do
+            direct <- directSerialiseToBS (fromIntegral $ sizeSignKeyKES (Proxy @v)) sk
+            prop_no_thunks_IO (return $! direct)
+      , testProperty "VerKey DirectDeserialise" $
+          ioPropertyWithSK @v lock $ \sk -> do
+            vk :: VerKeyKES v <- deriveVerKeyKES sk
+            direct <- directSerialiseToBS (fromIntegral $ sizeVerKeyKES (Proxy @v)) $! vk
+            prop_no_thunks_IO (directDeserialiseFromBS @IO @(VerKeyKES v) $! direct)
+      , testProperty "SignKey DirectDeserialise" $
+          ioPropertyWithSK @v lock $ \sk -> do
+            direct <- directSerialiseToBS (fromIntegral $ sizeSignKeyKES (Proxy @v)) sk
+            bracket
+              (directDeserialiseFromBS @IO @(SignKeyKES v) $! direct)
+              forgetSignKeyKES
+              (prop_no_thunks_IO . return)
       ]
 
     , testProperty "same VerKey "  $ prop_deriveVerKeyKES @v
+    , testProperty "no forgotten chunks in signkey" $ prop_noErasedBlocksInKey (Proxy @v)
     , testGroup "serialisation"
 
       [ testGroup "raw ser only"
@@ -312,6 +349,38 @@ testKESAlgorithm lock n =
             ioPropertyWithSK @v lock $ \sk -> do
               sig :: SigKES v <- signKES () 0 msg sk
               return $ prop_cbor_direct_vs_class encodeSigKES sig
+        ]
+
+      , testGroup "DirectSerialise"
+        [ testProperty "VerKey" $
+            ioPropertyWithSK @v lock $ \sk -> do
+              vk :: VerKeyKES v <- deriveVerKeyKES sk
+              serialized <- directSerialiseToBS (fromIntegral $ sizeVerKeyKES (Proxy @v)) vk
+              vk' <- directDeserialiseFromBS serialized
+              return $ vk === vk'
+        , testProperty "SignKey" $
+            ioPropertyWithSK @v lock $ \sk -> do
+              serialized <- directSerialiseToBS (fromIntegral $ sizeSignKeyKES (Proxy @v)) sk
+              equals <- bracket
+                          (directDeserialiseFromBS serialized)
+                          forgetSignKeyKES
+                          (\sk' -> sk ==! sk')
+              return $
+                counterexample ("Serialized: " ++ hexBS serialized ++ " (length: " ++ show (BS.length serialized) ++ ")") $
+                equals
+        ]
+      , testGroup "DirectSerialise matches raw"
+        [ testProperty "VerKey" $
+            ioPropertyWithSK @v lock $ \sk -> do
+              vk :: VerKeyKES v <- deriveVerKeyKES sk
+              direct <- directSerialiseToBS (fromIntegral $ sizeVerKeyKES (Proxy @v)) vk
+              let raw = rawSerialiseVerKeyKES vk
+              return $ direct === raw
+        , testProperty "SignKey" $
+            ioPropertyWithSK @v lock $ \sk -> do
+              direct <- directSerialiseToBS (fromIntegral $ sizeSignKeyKES (Proxy @v)) sk
+              raw <- rawSerialiseSignKeyKES sk
+              return $ direct === raw
         ]
       ]
 
@@ -675,4 +744,57 @@ withAllUpdatesKES seedPSB f = withMLockedSeedFromPSB seedPSB $ \seed -> do
           forgetSignKeyKES sk
           xs <- go sk' (t + 1)
           return $ x:xs
+
+withNullSeed :: forall m n a. (MonadThrow m, MonadST m, KnownNat n) => (MLockedSeed n -> m a) -> m a
+withNullSeed = bracket
+  (MLockedSeed <$> mlsbFromByteString (BS.replicate (fromIntegral $ natVal (Proxy @n)) 0))
+  mlockedSeedFinalize
+
+withNullSK :: forall m v a. (KESAlgorithm v, MonadThrow m, MonadST m)
+           => (SignKeyKES v -> m a) -> m a
+withNullSK = bracket
+  (withNullSeed genKeyKES)
+  forgetSignKeyKES
+
+
+-- | This test detects whether a sign key contains references to pool-allocated
+-- blocks of memory that have been forgotten by the time the key is complete.
+-- We do this based on the fact that the pooled allocator erases memory blocks
+-- by overwriting them with series of 0xff bytes; thus we cut the serialized
+-- key up into chunks of 16 bytes, and if any of those chunks is entirely
+-- filled with 0xff bytes, we assume that we're looking at erased memory.
+prop_noErasedBlocksInKey
+  :: forall v.
+     UnsoundKESAlgorithm v
+  => DirectSerialise IO (SignKeyKES v)
+  => Proxy v
+  -> Property
+prop_noErasedBlocksInKey kesAlgorithm =
+  ioProperty . withNullSK @IO @v $ \sk -> do
+    let size :: Int = fromIntegral $ sizeSignKeyKES kesAlgorithm
+    serialized <- allocaBytes size $ \ptr -> do
+      positionVar <- newMVar (0 :: Int)
+      directSerialise (\buf nCSize -> do
+          let n = fromIntegral nCSize :: Int
+          bracket
+            (takeMVar positionVar)
+            (putMVar positionVar . (+ n))
+            (\position -> do
+              when (n + position > size) (error "Buffer size exceeded")
+              copyMem (plusPtr ptr position) buf (fromIntegral n)
+            )
+        )
+        sk
+      packByteStringCStringLen (ptr, size)
+    forgetSignKeyKES sk
+    return $ counterexample (hexBS serialized) $ not (hasLongRunOfFF serialized)
+
+hasLongRunOfFF :: ByteString -> Bool
+hasLongRunOfFF bs
+  | BS.length bs < 16
+  = False
+  | otherwise
+  = let first16 = BS.take 16 bs
+        remainder = BS.drop 16 bs
+    in (BS.all (== 0xFF) first16) || hasLongRunOfFF remainder
 

--- a/cardano-crypto-tests/src/Test/Crypto/Util.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Util.hs
@@ -404,7 +404,7 @@ eitherShowError (Right a) = return a
 --------------------------------------------------------------------------------
 
 directSerialiseToBS :: forall m a.
-                       DirectSerialise m a
+                       DirectSerialise a
                     => MonadST m
                     => MonadThrow m
                     => MonadMVar m
@@ -423,7 +423,7 @@ directSerialiseToBS dstsize val = do
     packByteStringCStringLen (dst, fromIntegral dstsize)
 
 directDeserialiseFromBS :: forall m a.
-                           DirectDeserialise m a
+                           DirectDeserialise a
                            => MonadST m
                            => MonadThrow m
                            => MonadMVar m


### PR DESCRIPTION
Adds:

- **Direct serialization/deserialization of KES sign keys:** we need this in order to send keys over network sockets without touching the GHC heap (which would violate mlocking protections).
- **Cryptographic RNG:** a wrapper around `randombytes_buf()` from libsodium, to be used for generating mlocked seeds, such that we can generate KES sign keys entirely in mlocked memory.