### PR TITLE
Unbreak nix eval

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
             cabal = "3.10.1.0";
             ghcid = "0.8.8";
             haskell-language-server = "latest";
-            hlint = "3.8";
+            hlint = "3.6.1";
             weeder = "2.7.0";
           };
           # Now we use pkgsBuildBuild, to make sure that even in the cross

--- a/flake.nix
+++ b/flake.nix
@@ -54,8 +54,11 @@
             cabal = "3.10.1.0";
             ghcid = "0.8.8";
             haskell-language-server = "latest";
+            # ghc 9.2.8 comes with base 4.16.
+            # this disqualifies weeder > 2.4.1
+            # and hlint > 3.6.1
             hlint = "3.6.1";
-            weeder = "2.7.0";
+            weeder = "2.4.1";
           };
           # Now we use pkgsBuildBuild, to make sure that even in the cross
           # compilation setting, we don't run into issues where we pick tools


### PR DESCRIPTION
We need to match shell tools to the compiler. More recent hlint (3.8) is incompatible with ghc928.