### PR TITLE
Update for `io-classes-1.4` and friends

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -101,7 +101,7 @@ library
     , cryptonite
     , deepseq
     , heapwords
-    , io-classes
+    , io-classes >= 1.4.1
     , memory
     , mtl
     , nothunks

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Hash.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Hash.hs
@@ -49,13 +49,13 @@ expandHashWith
 expandHashWith allocator h (MLSB sfptr) = do
     withMLockedForeignPtr sfptr $ \ptr -> do
         l <- mlockedAllocaWith allocator size1 $ \ptr' -> do
-              withLiftST $ \liftST -> liftST . unsafeIOToST $ do
+              stToIO . unsafeIOToST $ do
                 poke ptr' (1 :: Word8)
                 copyMem (castPtr (plusPtr ptr' 1)) ptr size
                 naclDigestPtr h ptr' (fromIntegral size1)
 
         r <- mlockedAllocaWith allocator size1 $ \ptr' -> do
-              withLiftST $ \liftST -> liftST . unsafeIOToST $ do
+              stToIO . unsafeIOToST $ do
                 poke ptr' (2 :: Word8)
                 copyMem (castPtr (plusPtr ptr' 1)) ptr size
                 naclDigestPtr h ptr' (fromIntegral size1)

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes/Internal.hs
@@ -112,8 +112,8 @@ withMLSBChunk mlsb offset action
   = error $ "Overrun (" ++ show offset ++ " + " ++ show chunkSize ++ " > " ++ show parentSize ++ ")"
   | otherwise
   = withMLSB mlsb $ \ptr -> do
-      fptr <- withLiftST $ \lift -> do
-        lift $ unsafeIOToST (newForeignPtr_ . castPtr $ plusPtr ptr offset)
+      fptr <-
+        stToIO $ unsafeIOToST (newForeignPtr_ . castPtr $ plusPtr ptr offset)
       action (MLSB $! SFP $! fptr)
   where
     chunkSize = fromIntegral (natVal (Proxy @n'))
@@ -185,8 +185,7 @@ mlsbFromByteStringWith :: forall n m. (KnownNat n, MonadST m)
                        => MLockedAllocator m -> BS.ByteString -> m (MLockedSizedBytes n)
 mlsbFromByteStringWith allocator bs = do
   dst <- mlsbNewWith allocator
-  withMLSB dst $ \ptr -> do
-    withLiftST $ \liftST -> liftST . unsafeIOToST $ do
+  withMLSB dst $ \ptr -> stToIO . unsafeIOToST $ do
       BS.useAsCStringLen bs $ \(ptrBS, len) -> do
         copyMem (castPtr ptr) ptrBS (min (fromIntegral len) (mlsbSize dst))
   return dst
@@ -233,7 +232,7 @@ mlsbAsByteString mlsb@(MLSB (SFP fptr)) = BSI.PS (castForeignPtr fptr) 0 size
 mlsbToByteString :: forall n m. (KnownNat n, MonadST m) => MLockedSizedBytes n -> m BS.ByteString
 mlsbToByteString mlsb =
   withMLSB mlsb $ \ptr ->
-    withLiftST $ \liftST -> liftST . unsafeIOToST $ BS.packCStringLen (castPtr ptr, size)
+    stToIO . unsafeIOToST $ BS.packCStringLen (castPtr ptr, size)
   where
     size  :: Int
     size = fromIntegral (mlsbSize mlsb)
@@ -265,7 +264,7 @@ mlsbCompare :: forall n m. (MonadST m, KnownNat n) => MLockedSizedBytes n -> MLo
 mlsbCompare (MLSB x) (MLSB y) =
   withMLockedForeignPtr x $ \x' ->
     withMLockedForeignPtr y $ \y' -> do
-      res <- withLiftST $ \fromST -> fromST . unsafeIOToST $ c_sodium_compare x' y' size
+      res <- stToIO . unsafeIOToST $ c_sodium_compare x' y' size
       return $ compare res 0
   where
     size = fromInteger $ natVal (Proxy @n)

--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1707870123,
-        "narHash": "sha256-pOvz6uuPYw3CiPgi63QhNYumoKeyzDh9JOkLDngGWsE=",
+        "lastModified": 1708561382,
+        "narHash": "sha256-IDr2G3komoctjHALk8wGvDKOF39BaqrdEmjvAOsob5I=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "75345eba5d4159e6f54cbdc38785d1e0d0e655e0",
+        "rev": "4b07be837c34475fdde3c9bb9903a850b5692bac",
         "type": "github"
       },
       "original": {

--- a/strict-checked-vars/strict-checked-vars.cabal
+++ b/strict-checked-vars/strict-checked-vars.cabal
@@ -16,7 +16,7 @@ license-files:
 
 copyright:       2019-2023 Input Output Global Inc (IOG).
 author:          IOG Engineering Team
-maintainer:      operations@iohk.io
+maintainer:      operations@iohk.io, Joris Dral
 category:        Concurrency
 build-type:      Simple
 extra-doc-files:

--- a/strict-checked-vars/strict-checked-vars.cabal
+++ b/strict-checked-vars/strict-checked-vars.cabal
@@ -50,9 +50,9 @@ library
   default-language: Haskell2010
   build-depends:
     , base         >=4.9 && <5
-    , io-classes   >=1.2 && <1.4
-    , strict-mvar  >=1.2 && <1.4
-    , strict-stm   >=1.2 && <1.4
+    , io-classes   >=1.2 && <1.5
+    , strict-mvar  >=1.2 && <1.5
+    , strict-stm   >=1.2 && <1.5
 
   ghc-options:
     -Wall -Wcompat -Wincomplete-uni-patterns


### PR DESCRIPTION
Mirroring https://github.com/IntersectMBO/cardano-haskell-packages/pull/672

Code changes are due to the deprecation of `withLiftST`; now, `MonadST` provides a generic [`stToIO`](https://hackage.haskell.org/package/io-classes-1.4.1.0/docs/Control-Monad-Class-MonadST.html#t:MonadST).