### PR TITLE
Cache `dist-newstyle` Build Artifacts to Speed Up GitHub Codespace First-Launch Time

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.ghc96-iog
+COPY .. /workspaces/cardano-base
+RUN bash -ic "post-create-command"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-   "image":"ghcr.io/input-output-hk/devx-devcontainer:ghc962-iog",
+   "dockerFile":"./Dockerfile",
    "customizations":{
       "vscode":{
          "extensions":[

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.7", "9.6.2", "9.8.1"]
+        ghc: ["8.10.7", "9.2.7", "9.6.4", "9.8.1"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     env:
@@ -148,3 +148,9 @@ jobs:
     #  uses: mxschmitt/action-tmate@v3
     #  with:
     #     limit-access-to-actor: true
+
+    - name: Cache HLS artifacts (used to speed up GitHub Codespaces bootstrapping)
+      if: runner.os == 'Linux' && (matrix.ghc == '8.10.7' || matrix.ghc == '9.6.4')
+      uses: input-output-hk/actions/cache@latest
+      with:
+        ghc_version: ${{ matrix.ghc == '8.10.7' && 'ghc810' || matrix.ghc == '9.6.4' && 'ghc96' }}


### PR DESCRIPTION
This updates the GitHub Actions `build` workflow to create a per-commit artifact containing the contents of `$HOME/.cache`, but only for `x86_64-linux`.

The motivation behind this change is to speed up the initial launch of GitHub Codespace. HLS requires the project to be already built to be ready to use.

This PR opts into a feature that is implemented directly in the Codespace image, detailed in [this PR](https://github.com/input-output-hk/devx/pull/128).