### PR TITLE
Add cardano-git-rev package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,9 +10,9 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 -- The hackage index-state
-index-state: 2024-02-14T22:42:30Z
+index-state: 2024-03-11T03:33:05Z
 -- The CHaP index-state
-index-state: cardano-haskell-packages 2024-02-14T10:17:08Z
+index-state: cardano-haskell-packages 2024-03-08T10:14:14Z
 
 packages:
   base-deriving-via
@@ -21,6 +21,7 @@ packages:
   cardano-crypto-class
   cardano-crypto-praos
   cardano-crypto-tests
+  cardano-git-rev
   cardano-slotting
   cardano-strict-containers
   cardano-mempool

--- a/cardano-git-rev/LICENSE
+++ b/cardano-git-rev/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/cardano-git-rev/NOTICE
+++ b/cardano-git-rev/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2022-2023 Input Output Global Inc (IOG).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/cardano-git-rev/README.md
+++ b/cardano-git-rev/README.md
@@ -1,0 +1,11 @@
+# Cardano Git Rev
+
+This package exposes functions to provide git information for `cardano-node`.
+
+`cardano-node` support building via `nix` and `cabal`
+
+When building with `nix` the git executable and git metadata isn't available so the
+git revision is embedded as a series of 40 zeros during the build. After the nix build
+is finished the executable is patched with the correct git sha. See [set-git-rev.hs][set-git-rev.hs]
+
+[set-git-rev.hs]: https://github.com/input-output-hk/iohk-nix/blob/master/overlays/haskell-nix-extra/utils/set-git-rev.hs

--- a/cardano-git-rev/Setup.hs
+++ b/cardano-git-rev/Setup.hs
@@ -1,0 +1,2 @@
+import           Distribution.Simple
+main = defaultMain

--- a/cardano-git-rev/cardano-git-rev.cabal
+++ b/cardano-git-rev/cardano-git-rev.cabal
@@ -1,0 +1,41 @@
+cabal-version: 3.0
+
+name:                   cardano-git-rev
+version:                0.2.0.0
+synopsis:               Git revisioning
+description:            Embeds git revision into Haskell packages.
+category:               Cardano,
+                        Versioning,
+copyright:              2022-2023 Input Output Global Inc (IOG).
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-source-files:     README.md
+
+common project-config
+  default-language:     Haskell2010
+  build-depends:        base >= 4.14 && < 5
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+library
+  import:               project-config
+
+  hs-source-dirs:       src
+  c-sources:            cbits/rev.c
+
+  exposed-modules:      Cardano.Git.Rev
+                        Cardano.Git.RevFromGit
+
+  build-depends:        process
+                      , template-haskell
+                      , text

--- a/cardano-git-rev/cbits/rev.c
+++ b/cardano-git-rev/cbits/rev.c
@@ -1,0 +1,11 @@
+// <magic: fe> <marker: gitrev> <size: padded to 20 bytes> <space for gitrev (40 char)>
+char _cardano_git_rev[68]
+  = "fe"
+    "gitrev"
+    "0000000000"
+    "0000000040"
+    "0000000000"
+    "0000000000"
+    "0000000000"
+    "0000000000"
+    ;

--- a/cardano-git-rev/src/Cardano/Git/Rev.hs
+++ b/cardano-git-rev/src/Cardano/Git/Rev.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Cardano.Git.Rev
+  ( gitRev
+  ) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+#if !defined(arm_HOST_ARCH)
+import           Cardano.Git.RevFromGit (gitRevFromGit)
+#endif
+import           Foreign.C.String (CString)
+import           GHC.Foreign (peekCStringLen)
+import           Language.Haskell.TH (Exp, Q)
+import           System.IO (utf8)
+import           System.IO.Unsafe (unsafeDupablePerformIO)
+
+foreign import ccall "&_cardano_git_rev" c_gitrev :: CString
+
+-- This must be a TH splice to ensure the git commit is captured at build time.
+-- ie called as `$(gitRev)`.
+gitRev :: Q Exp
+gitRev =
+    [| if
+         | gitRevEmbed /= zeroRev -> gitRevEmbed
+         | T.null fromGit         -> zeroRev
+         | otherwise              -> fromGit
+    |]
+
+-- Git revision embedded after compilation using
+-- Data.FileEmbed.injectWith. If nothing has been injected,
+-- this will be filled with 0 characters.
+gitRevEmbed :: Text
+gitRevEmbed = T.pack $ drop 28 $ unsafeDupablePerformIO (peekCStringLen utf8 (c_gitrev, 68))
+
+-- Git revision found during compilation by running git. If
+-- git could not be run, then this will be empty.
+fromGit :: Text
+#if defined(arm_HOST_ARCH)
+  -- cross compiling to arm fails; due to a linker bug
+fromGit = ""
+#else
+fromGit = T.strip (T.pack $(gitRevFromGit))
+#endif
+
+zeroRev :: Text
+zeroRev = "0000000000000000000000000000000000000000"

--- a/cardano-git-rev/src/Cardano/Git/RevFromGit.hs
+++ b/cardano-git-rev/src/Cardano/Git/RevFromGit.hs
@@ -1,0 +1,33 @@
+module Cardano.Git.RevFromGit
+  ( gitRevFromGit
+  ) where
+
+import           Control.Exception (catch)
+import           System.Exit (ExitCode (..))
+import qualified System.IO as IO
+import           System.IO.Error (isDoesNotExistError)
+import           System.Process (readProcessWithExitCode)
+
+import qualified Language.Haskell.TH as TH
+
+-- | Git revision found by running git rev-parse. If git could not be
+-- executed, then this will be an empty string.
+gitRevFromGit :: TH.Q TH.Exp
+gitRevFromGit =
+  TH.LitE . TH.StringL <$> TH.runIO runGitRevParse
+ where
+  runGitRevParse :: IO String
+  runGitRevParse = do
+    (exitCode, output, errorMessage) <- readProcessWithExitCode_ "git" ["rev-parse", "--verify", "HEAD"] ""
+    case exitCode of
+      ExitSuccess -> pure output
+      ExitFailure _ -> do
+        IO.hPutStrLn IO.stderr $ "WARNING: " ++ errorMessage
+        pure ""
+
+  readProcessWithExitCode_ :: FilePath -> [String] -> String -> IO (ExitCode, String, String)
+  readProcessWithExitCode_ cmd args input =
+    catch (readProcessWithExitCode cmd args input) $ \e ->
+    if isDoesNotExistError e
+    then return (ExitFailure 127, "", show e)
+    else return (ExitFailure 999, "", show e)


### PR DESCRIPTION
This package was originally in the `cardano-node` repo but was also used in `cardano-cli`. However this package exports a function `gitRev` but the way its built can result in an incorrect git hash.

The solution is the change the `gitRev` function into TH splce so that it will always be run at the call site.

Now that this operates correctly, it makes more sense for this package to be here so it can be used in any executable in the Cardano/Haskell stack.