### PR TITLE
cardano-git-rev: Perform check for embedded git rev at run time 

### DIFF
--- a/cardano-git-rev/src/Cardano/Git/Rev.hs
+++ b/cardano-git-rev/src/Cardano/Git/Rev.hs
@@ -1,8 +1,14 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
+
+#if __GLASGOW_HASKELL__ >= 900
+{-# LANGUAGE TemplateHaskellQuotes #-}
+#else
+-- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2288
+{-# LANGUAGE TemplateHaskell #-}
+#endif
 
 module Cardano.Git.Rev
   ( gitRev

--- a/cardano-git-rev/src/Cardano/Git/Rev.hs
+++ b/cardano-git-rev/src/Cardano/Git/Rev.hs
@@ -32,10 +32,11 @@ foreign import ccall "&_cardano_git_rev" c_gitrev :: CString
 -- This must be a TH splice to ensure the git commit is captured at build time.
 -- ie called as `$(gitRev)`.
 gitRev :: Q Exp
-gitRev
-  | gitRevEmbed /= zeroRev = textE gitRevEmbed
-  | otherwise              =
-      textE =<< TH.runIO runGitRevParse
+gitRev =
+    [| if
+         | gitRevEmbed /= zeroRev -> gitRevEmbed
+         | otherwise              -> $(textE =<< TH.runIO runGitRevParse)
+    |]
 
 -- Git revision embedded after compilation using
 -- Data.FileEmbed.injectWith. If nothing has been injected,


### PR DESCRIPTION
Follow-up to #467, see the second commit message.