### PR TITLE
Downgrade to MacOS-13 since newest does not support < GHC-9.2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,7 +38,17 @@ jobs:
       fail-fast: false
       matrix:
         ghc: ["8.10.7", "9.2.8", "9.6.4", "9.8.2"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        # GHC versions older than ghc-9.2 are not supported on macos-latest
+        exclude:
+          - os: macos-latest
+            ghc: "8.10.7"
+          - os: macos-13
+            ghc: "9.2.8"
+          - os: macos-13
+            ghc: "9.6.4"
+          - os: macos-13
+            ghc: "9.8.2"
 
     env:
       # Modify this value to "invalidate" the cabal cache.


### PR DESCRIPTION
We'll remove macos-13 once we drop support for GHC-8.10