### PR TITLE
Serialisation support for Genesis big ledger peer snapshot

### DIFF
--- a/cardano-slotting/CHANGELOG.md
+++ b/cardano-slotting/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 0.2.0.1
 
-*
+* ToCBOR and FromCBOR instances for SlotNo directly encode the slot number
+* Made FromCBOR and ToCBOR instances for WithOrigin overlappable. One specific
+  use case is an overlapping instance for WithOrigin SlotNo in
+  ouroboros-network-api.
 
 ## 0.2.0.0
 

--- a/cardano-slotting/cardano-slotting.cabal
+++ b/cardano-slotting/cardano-slotting.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                cardano-slotting
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            Key slotting types for cardano libraries
 license:             Apache-2.0
 license-files:

--- a/cardano-slotting/src/Cardano/Slotting/Slot.hs
+++ b/cardano-slotting/src/Cardano/Slotting/Slot.hs
@@ -40,11 +40,11 @@ newtype SlotNo = SlotNo {unSlotNo :: Word64}
   deriving newtype (Enum, Bounded, Num, NFData, Serialise, NoThunks, ToJSON, FromJSON)
 
 instance ToCBOR SlotNo where
-  toCBOR = encode
+  toCBOR (SlotNo word64) = toCBOR word64
   encodedSizeExpr size = encodedSizeExpr size . fmap unSlotNo
 
 instance FromCBOR SlotNo where
-  fromCBOR = decode
+  fromCBOR = SlotNo <$> fromCBOR
 
 {-------------------------------------------------------------------------------
   WithOrigin
@@ -63,10 +63,10 @@ data WithOrigin t = Origin | At !t
       NoThunks
     )
 
-instance (Serialise t, Typeable t) => ToCBOR (WithOrigin t) where
+instance {-# OVERLAPPABLE #-} (Serialise t, Typeable t) => ToCBOR (WithOrigin t) where
   toCBOR = encode
 
-instance (Serialise t, Typeable t) => FromCBOR (WithOrigin t) where
+instance {-# OVERLAPPABLE #-} (Serialise t, Typeable t) => FromCBOR (WithOrigin t) where
   fromCBOR = decode
 
 instance Bounded t => Bounded (WithOrigin t) where


### PR DESCRIPTION
Networking team needs to pin down CBOR encoding for CDDL spec of the big ledger peer snapshot format.