### PR TITLE
Revert "Updated strict-checked-vars to io-classes-1.7"

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,7 +10,7 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 -- The hackage index-state
-index-state: hackage.haskell.org 2024-08-27T18:06:30Z
+index-state: 2024-06-12T11:52:25Z
 -- The CHaP index-state
 index-state: cardano-haskell-packages 2024-06-12T11:52:25Z
 

--- a/strict-checked-vars/strict-checked-vars.cabal
+++ b/strict-checked-vars/strict-checked-vars.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            strict-checked-vars
-version:         0.2.0.1
+version:         0.2.0.0
 synopsis:
   Strict MVars and TVars with invariant checking for IO and IOSim
 
@@ -50,7 +50,9 @@ library
   default-language: Haskell2010
   build-depends:
     , base         >=4.9 && <5
-    , io-classes:{io-classes,strict-mvar,strict-stm}  ^>=1.7
+    , io-classes   >=1.2 && <1.6
+    , strict-mvar  >=1.2 && <1.6
+    , strict-stm   >=1.2 && <1.6
 
   ghc-options:
     -Wall -Wcompat -Wincomplete-uni-patterns
@@ -77,7 +79,7 @@ test-suite test
   default-language: Haskell2010
   build-depends:
     , base
-    , io-classes:io-classes
+    , io-classes
     , io-sim
     , nothunks
     , QuickCheck


### PR DESCRIPTION
This reverts commit 8a5991475e4234f196a23aeb18cc4b2b42b16e22.

Haskell.nix doesn't support `io-classes ^>= 1.7`; we will stick with `io-classes ^>= 1.5`, which doesn't use public sublibraries at all.
