### PR TITLE
Add VRF support for the SPO polling use case

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -125,8 +126,8 @@ class ( Typeable v
     => ContextVRF v
     -> VerKeyVRF v
     -> a
-    -> (OutputVRF v, CertVRF v)
-    -> Bool
+    -> CertVRF v
+    -> Maybe (OutputVRF v)
 
   --
   -- Key generation
@@ -334,7 +335,10 @@ verifyCertified
   -> a
   -> CertifiedVRF v a
   -> Bool
-verifyCertified ctxt vk a CertifiedVRF {..} = verifyVRF ctxt vk a (certifiedOutput, certifiedProof)
+verifyCertified ctxt vk a CertifiedVRF {certifiedOutput, certifiedProof} =
+    case verifyVRF ctxt vk a certifiedProof of
+      Nothing     -> False
+      Just output -> output == certifiedOutput
 
 --
 -- 'Size' expressions for 'ToCBOR' instances

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -58,7 +58,11 @@ instance VRFAlgorithm MockVRF where
 
   evalVRF () a sk = evalVRF' a sk
 
-  verifyVRF () (VerKeyMockVRF n) a c = evalVRF' a (SignKeyMockVRF n) == c
+  verifyVRF () (VerKeyMockVRF n) a c
+      | c == c'   = Just o
+      | otherwise = Nothing
+    where
+      (o, c') = evalVRF' a (SignKeyMockVRF n)
 
   sizeOutputVRF _ = sizeHash (Proxy :: Proxy ShortHash)
 

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -152,19 +152,21 @@ instance VRFAlgorithm SimpleVRF where
         s = mod (r + k * fromIntegral (bytesToNatural c)) q
     in (OutputVRF y, CertSimpleVRF u (bytesToNatural c) s)
 
-  verifyVRF () (VerKeySimpleVRF v) a' (OutputVRF y, cert) =
+  verifyVRF () (VerKeySimpleVRF v) a' cert =
     let a = getSignableRepresentation a'
         u = certU cert
         c = certC cert
         c' = -fromIntegral c
         s = certS cert
-        b1 = y == h (toCBOR a <> toCBOR u)
+        o = h (toCBOR a <> toCBOR u)
         rhs =
           h $ toCBOR a <>
             toCBOR v <>
             toCBOR (pow s <> pow' v c') <>
             toCBOR (h' (toCBOR a) s <> pow' u c')
-    in b1 && c == bytesToNatural rhs
+    in if c == bytesToNatural rhs
+         then Just (OutputVRF o)
+         else Nothing
 
   sizeOutputVRF _ = sizeHash (Proxy :: Proxy H)
 

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -67,7 +67,7 @@ library
   build-depends:        base
                       , bytestring
                       , cardano-binary
-                      , cardano-crypto-class >=2.1
+                      , cardano-crypto-class >= 2.1.1
                       , deepseq
                       , nothunks
 

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -77,7 +77,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Coerce (coerce)
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
 import Foreign.C.Types
 import Foreign.ForeignPtr
@@ -507,8 +507,8 @@ instance VRFAlgorithm PraosVRF where
         !output = maybe (error "Invalid Proof") outputBytes $ outputFromProof proof
      in (OutputVRF output, CertPraosVRF proof)
 
-  verifyVRF = \_ (VerKeyPraosVRF pk) msg (_, CertPraosVRF proof) ->
-    isJust $! verify pk proof (getSignableRepresentation msg)
+  verifyVRF = \_ (VerKeyPraosVRF pk) msg (CertPraosVRF proof) ->
+    (OutputVRF . outputBytes) <$> verify pk proof (getSignableRepresentation msg)
 
   sizeOutputVRF _ = fromIntegral crypto_vrf_outputbytes
   seedSizeVRF _ = fromIntegral crypto_vrf_seedbytes

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
@@ -76,7 +76,7 @@ import Control.Monad (void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Coerce (coerce)
-import Data.Maybe (isJust, fromMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
 import Foreign.C.Types
 import Foreign.ForeignPtr
@@ -484,8 +484,8 @@ instance VRFAlgorithm PraosBatchCompatVRF where
     in output `seq` proof `seq`
            (OutputVRF (outputBytes output), CertPraosBatchCompatVRF proof)
 
-  verifyVRF = \_ (VerKeyPraosBatchCompatVRF pk) msg (_, CertPraosBatchCompatVRF proof) ->
-    isJust $! verify pk proof (getSignableRepresentation msg)
+  verifyVRF = \_ (VerKeyPraosBatchCompatVRF pk) msg (CertPraosBatchCompatVRF proof) ->
+    (OutputVRF . outputBytes) <$> verify pk proof (getSignableRepresentation msg)
 
   sizeOutputVRF _ = fromIntegral crypto_vrf_ietfdraft13_outputbytes
   seedSizeVRF _ = fromIntegral crypto_vrf_ietfdraft13_seedbytes

--- a/cardano-crypto-tests/src/Bench/Crypto/VRF.hs
+++ b/cardano-crypto-tests/src/Bench/Crypto/VRF.hs
@@ -49,9 +49,9 @@ benchVRF _ lbl =
         nf (evalVRF @v () typicalMsg) signKey
 
     , env (let (sk, vk) = genKeyPairVRF @v testSeed
-               (output, cert) = evalVRF @v () typicalMsg sk
-            in return (vk, output, cert)
-          ) $ \ ~(vk, output, cert) ->
+               (_output, cert) = evalVRF @v () typicalMsg sk
+            in return (vk, cert)
+          ) $ \ ~(vk, cert) ->
       bench "verify" $
-        nf (verifyVRF () vk typicalMsg) (output, cert)
+        nf (verifyVRF () vk typicalMsg) cert
     ]

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1707917276,
-        "narHash": "sha256-Y4l/aeyOAsOGVypAabuxzXbKoOd1xM+JNCYG//jnh3A=",
+        "lastModified": 1725372492,
+        "narHash": "sha256-eQwfZIEHH5qHZQHXujgjj35dVAqSZa6EbTRWeppn1ME=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bb334e5a25a872fc0c879d01afc0e1b7990483a3",
+        "rev": "05c9f8fb28fde6e46d8768ce396a4482883d6bab",
         "type": "github"
       },
       "original": {
@@ -36,17 +36,17 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
+        "ref": "v0.3.11",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
         "type": "github"
       }
     },
@@ -120,11 +120,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -146,6 +146,22 @@
       "original": {
         "owner": "input-output-hk",
         "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -186,51 +202,35 @@
         "type": "github"
       }
     },
-    "ghc98X": {
-      "flake": false,
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1696643148,
-        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
-        "ref": "ghc-9.8",
-        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
-        "revCount": 61642,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
       },
       "original": {
-        "ref": "ghc-9.8",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc99": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1697054644,
-        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
-        "ref": "refs/heads/master",
-        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
-        "revCount": 62040,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
       }
     },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1708561382,
-        "narHash": "sha256-IDr2G3komoctjHALk8wGvDKOF39BaqrdEmjvAOsob5I=",
+        "lastModified": 1725409900,
+        "narHash": "sha256-XfSA7YyjHUfuNsCw4cE6p0kQcmrJgQq3nW36Cw/PAv0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4b07be837c34475fdde3c9bb9903a850b5692bac",
+        "rev": "d86e544dec33ce5fb0ad3981be91074d397b700d",
         "type": "github"
       },
       "original": {
@@ -248,14 +248,17 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc98X": "ghc98X",
-        "ghc99": "ghc99",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -269,16 +272,18 @@
         "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1699404571,
-        "narHash": "sha256-EwI7vKBxCHvIKPWbvGlOF9IZlSFqPODgT/BQy8Z2s/w=",
+        "lastModified": 1725411053,
+        "narHash": "sha256-cW999pULNLOZHlV9sqBFIrWTkSxuVAVR6xJR7GndHdQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cec253ca482301509e9e90cb5c15299dd3550cce",
+        "rev": "63783ecc949e99b2396ca821275cee26385adaba",
         "type": "github"
       },
       "original": {
@@ -358,16 +363,101 @@
     "hls-2.4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696939266,
-        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.4.0.0",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718469202,
+        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -419,11 +509,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1707581561,
-        "narHash": "sha256-A9MT8D7M2We0HCBQbClrA91ZquGf7GU+T6tvjMeUUEA=",
+        "lastModified": 1721825987,
+        "narHash": "sha256-PPcma4tjozwXJAWf+YtHUQUulmxwulVlwSQzKItx/n8=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "51469c3fc2c74e24b529f63615670259ba1fee38",
+        "rev": "eb61f2c14e1f610ec59117ad40f8690cddbf80cb",
         "type": "github"
       },
       "original": {
@@ -435,18 +525,18 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1691634696,
-        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
-        "ref": "hkm/remote-iserv",
-        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
-        "revCount": 14,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
       },
       "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
       }
     },
     "lowdown-src": {
@@ -584,16 +674,48 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1695416179,
-        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1720122915,
+        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -614,13 +736,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1720181791,
+        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
         "type": "github"
       },
       "original": {
@@ -646,6 +784,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1719082008,
+        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -663,6 +817,27 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1724857454,
+        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "CHaP": "CHaP",
@@ -673,7 +848,8 @@
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
-        ]
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     },
     "secp256k1": {
@@ -713,11 +889,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1699402155,
-        "narHash": "sha256-fOywUFLuAuZAkIrv1JdjGzfY53uEiMRlu8UpdJtCjh0=",
+        "lastModified": 1725408838,
+        "narHash": "sha256-tHw95xcMElCqI6xOLmdTAEvQ0/4IS7WBZc+RF7HT/uk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "7c7bfe8cca23c96b850e16f3c0b159aca1850314",
+        "rev": "2ab3b5a823933ef199a289fbf39bbf0da0023100",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,44 +1,61 @@
 {
+  description = "cardano-base";
+
   inputs = {
     haskellNix.url = "github:input-output-hk/haskell.nix";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     iohkNix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
 
-    CHaP.url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
-    CHaP.flake = false;
+    CHaP = {
+      url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
+      flake = false;
+    };
 
     # non-flake nix compatibility
-    flake-compat.url = "github:edolstra/flake-compat";
-    flake-compat.flake = false;
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
   };
 
-  outputs = inputs:
-    let
-      profiling = false;
-      supportedSystems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        # not supported on ci.iog.io right now
-        #"aarch64-linux"
-        "aarch64-darwin"
-       ]; in
-    inputs.flake-utils.lib.eachSystem supportedSystems (system:
-      let
+  outputs = inputs: let
+    supportedSystems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      # "aarch64-linux" - disable these temporarily because the build is broken
+      "aarch64-darwin"
+    ];
+  in
+    inputs.flake-utils.lib.eachSystem supportedSystems (
+      system: let
         # setup our nixpkgs with the haskell.nix overlays, and the iohk-nix
         # overlays...
         nixpkgs = import inputs.nixpkgs {
-          overlays = [inputs.haskellNix.overlay] ++ builtins.attrValues inputs.iohkNix.overlays;
+          overlays = [
+            # iohkNix.overlays.crypto provide libsodium-vrf, libblst and libsecp256k1.
+            inputs.iohkNix.overlays.crypto
+            # haskellNix.overlay can be configured by later overlays, so need to come before them.
+            inputs.haskellNix.overlay
+            # configure haskell.nix to use iohk-nix crypto librairies.
+            inputs.iohkNix.overlays.haskell-nix-crypto
+          ];
           inherit system;
           inherit (inputs.haskellNix) config;
         };
-        # ... and construct a flake from the cabal.project file.
+        inherit (nixpkgs) lib;
+
+        # see flake `variants` below for alternative compilers
+        defaultCompiler = "ghc966";
+        fourmoluVersion = "0.16.2.0";
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
-        flake = (nixpkgs.haskell-nix.cabalProject' rec {
+        cabalProject = nixpkgs.haskell-nix.cabalProject' ({config, ...}: {
           src = ./.;
           name = "cardano-base";
-          compiler-nix-name = "ghc928";
+          compiler-nix-name = lib.mkDefault defaultCompiler;
 
           # CHaP input map, so we can find CHaP packages (needs to be more
           # recent than the index-state we set!). Can be updated with
@@ -48,26 +65,45 @@
           inputMap = {
             "https://chap.intersectmbo.org/" = inputs.CHaP;
           };
+          cabalProjectLocal = ''
+            repository cardano-haskell-packages-local
+              url: file:${inputs.CHaP}
+              secure: True
+            active-repositories: hackage.haskell.org, cardano-haskell-packages-local
+          '';
 
-          # tools we want in our shell
-          shell.tools = {
-            cabal = "3.10.1.0";
-            ghcid = "0.8.8";
-            haskell-language-server = "latest";
-            # ghc 9.2.8 comes with base 4.16.
-            # this disqualifies weeder > 2.4.1
-            # and hlint > 3.6.1
-            hlint = "3.6.1";
-            weeder = "2.4.1";
+          shell = {
+            # force LANG to be UTF-8, otherwise GHC might choke on UTF encoded data.
+            shellHook = ''
+              export LANG=en_US.UTF-8
+              export LC_ALL=en_US.UTF-8
+            '' + lib.optionalString (nixpkgs.glibcLocales != null && nixpkgs.stdenv.hostPlatform.libc == "glibc") ''
+              export LOCALE_ARCHIVE="${nixpkgs.glibcLocales}/lib/locale/locale-archive"
+            '';
+
+            # tools we want in our shell, from hackage
+            tools =
+              {
+                cabal = "3.12.1.0";
+                ghcid = "0.8.9";
+              }
+              // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
+                # tools that work only with default compiler
+                fourmolu = fourmoluVersion;
+                hlint = "3.8";
+                haskell-language-server = "2.9.0.0";
+              };
+
+            # and from nixpkgs or other inputs
+            nativeBuildInputs = with nixpkgs;
+              [
+                haskellPackages.implicit-hie
+              ];
+            # disable Hoogle until someone request it
+            withHoogle = false;
+            # Skip cross compilers for the shell
+            crossPlatforms = _: [];
           };
-          # Now we use pkgsBuildBuild, to make sure that even in the cross
-          # compilation setting, we don't run into issues where we pick tools
-          # for the target.
-          shell.buildInputs = with nixpkgs.pkgsBuildBuild; [
-            gitAndTools.git
-            sqlite-interactive
-          ];
-          shell.withHoogle = true;
 
           # package customizations as needed. Where cabal.project is not
           # specific enough, or doesn't allow setting these.
@@ -83,7 +119,6 @@
               packages.cardano-binary.configureFlags = [ "--ghc-option=-Werror" ];
               packages.cardano-crypto-class.configureFlags = [ "--ghc-option=-Werror" ];
               packages.slotting.configureFlags = [ "--ghc-option=-Werror" ];
-              enableLibraryProfiling = profiling;
             })
             ({pkgs, ...}: with pkgs; nixpkgs.lib.mkIf stdenv.hostPlatform.isWindows {
               packages.text.flags.simdutf = false;
@@ -103,28 +138,78 @@
               packages.network.components.library.build-tools = lib.mkForce [];
             })
           ];
-        }).flake (
-          # we also want cross compilation to windows.
-          nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
-          crossPlatforms = p: [p.mingwW64];
         });
-      in nixpkgs.lib.recursiveUpdate flake {
-        # add a required job, that's basically all hydraJobs.
-        hydraJobs = nixpkgs.callPackages inputs.iohkNix.utils.ciJobsAggregates
-          { ciJobs = flake.hydraJobs; };
-      }
+        # ... and construct a flake from the cabal project
+        flake =
+          cabalProject.flake (
+            lib.optionalAttrs (system == "x86_64-linux") {
+              # on linux, build/test other supported compilers
+              variants = lib.genAttrs ["ghc8107" "ghc982"] (compiler-nix-name: {
+                inherit compiler-nix-name;
+              });
+              # we also want cross compilation to windows.
+              crossPlatforms = p: [p.mingwW64];
+            }
+          );
+      in
+        lib.recursiveUpdate flake rec {
+          project = cabalProject;
+          # add a required job, that's basically all hydraJobs.
+          hydraJobs =
+            nixpkgs.callPackages inputs.iohkNix.utils.ciJobsAggregates
+            {
+              ciJobs =
+                flake.hydraJobs
+                // {
+                  # This ensure hydra send a status for the required job (even if no change other than commit hash)
+                  revision = nixpkgs.writeText "revision" (inputs.self.rev or "dirty");
+                };
+            };
+          legacyPackages = {
+            inherit cabalProject nixpkgs;
+            # also provide hydraJobs through legacyPackages to allow building without system prefix:
+            inherit hydraJobs;
+          };
+
+          devShells = let
+            mkDevShells = p: {
+              # `nix develop .#profiling` (or `.#ghc966.profiling): a shell with profiling enabled
+              profiling = (p.appendModule {modules = [{enableLibraryProfiling = true;}];}).shell;
+              # `nix develop .#pre-commit` (or `.#ghc966.pre-commit): a shell with pre-commit enabled
+              pre-commit = let
+                pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
+                  src = ./.;
+                  hooks = {
+                    fourmolu.enable = true;
+                  };
+                  tools = {
+                    fourmolu = p.tool "fourmolu" fourmoluVersion;
+                  };
+                };
+              in
+                p.shell.overrideAttrs (old: {
+                  shellHook = old.shellHook + pre-commit-check.shellHook;
+              });
+            };
+          in
+            mkDevShells cabalProject
+            # Additional shells for every GHC version supported by haskell.nix, eg. `nix develop .#ghc8107`
+            // lib.mapAttrs (compiler-nix-name: _: let
+              p = cabalProject.appendModule {inherit compiler-nix-name;};
+            in
+              p.shell // (mkDevShells p))
+            nixpkgs.haskell-nix.compiler;
+          # formatter used by nix fmt
+          formatter = nixpkgs.alejandra;
+        }
     );
 
   nixConfig = {
     extra-substituters = [
       "https://cache.iog.io"
-      # drop this, once we stop needing it; when we have stable aarch64-darwin
-      # builds
-      "https://cache.zw3rk.com"
     ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-      "loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk="
     ];
     allow-import-from-derivation = true;
   };


### PR DESCRIPTION
Reviving Duncan's PR #403 

[`cardano-crypto-class-2.1.4.0`](https://github.com/IntersectMBO/cardano-base/compare/cardano-crypto-class-2.1.4.0) and [`cardano-crypto-praos-2.1.2.0`](https://github.com/IntersectMBO/cardano-base/compare/cardano-crypto-praos-2.1.2.0) have already been released with this change, but it is not yet on master.