### PR TITLE
Fix recent changes to haddock generation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Github Pages
+name: Haddocks to GitHub Pages
 
 on:
   push:
@@ -12,47 +12,72 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Install nix
-        uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
-            substituters = https://cache.iog.io https://cache.nixos.org/ https://cache.zw3rk.com
-      - name: Build projects and haddocks
-        run: nix develop --command bash -c "cabal update && cabal build --enable-documentation all && ./scripts/haddocks.sh"
-      - name: Add files
-        run: |
-              git config --local user.name ${{ github.actor }}
-              git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+    - uses: actions/checkout@v4
 
-              # Start a new version of the gh-pages branch
-              git for-each-ref refs/heads/gh-pages --format='%(refname:short)' |
-                while read -r REFNAME; do
-                  git branch -D "$REFNAME"
-                done
-              git checkout -b gh-pages
+    - name: Install Haskell
+      uses: input-output-hk/setup-haskell@v1
+      id: setup-haskell
+      with:
+        ghc-version: "9.2.8"
+        cabal-version: latest
 
-              git rm -rfq .
-              git commit -qm "Remove all existing files"
+    - name: Install system dependencies
+      uses: input-output-hk/actions/base@latest
+      with:
+        use-sodium-vrf: false # default is true
 
-              echo "cardano-base.cardano.intersectmbo.org" >CNAME
-              touch .nojekyll
-              git add CNAME .nojekyll
-              git commit -qm "Add CNAME and .nojekyll"
+    - name: Configure to use libsodium
+      run: |
+        cat >> cabal.project <<EOF
+        package cardano-crypto-praos
+          flags: -external-libsodium-vrf
+        EOF
 
-              # Add Haddocks
-              git add -A --force ./haddocks
-              git mv ./haddocks/* .
-              git commit -qm "Updated from ${GITHUB_SHA} via ${GITHUB_EVENT_NAME}"
+    - name: Cabal update
+      run: cabal update
 
-      - name: Push to gh-pages
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            branch: gh-pages
-            force: true
-            directory: .
+    - name: Build haddocks
+      run: scripts/haddocks.sh haddocks all
 
+    - name: Add files
+      run: |
+        git config --local user.name ${{ github.actor }}
+        git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+
+        # Start a new version of the gh-pages branch
+        git for-each-ref refs/heads/gh-pages --format='%(refname:short)' |
+          while read -r REFNAME; do
+            git branch -D "$REFNAME"
+          done
+        git checkout -b gh-pages
+
+        git rm -rfq .
+        git commit -qm "Remove all existing files"
+
+        echo "cardano-base.cardano.intersectmbo.org" >CNAME
+        touch .nojekyll
+        git add CNAME .nojekyll
+        git commit -qm "Add CNAME and .nojekyll"
+
+        # Preserve benchmark results, if any
+        git ls-remote origin --heads gh-pages |
+          while read -r _SHA REFNAME; do
+            git fetch origin "$REFNAME"
+            if git diff --name-only FETCH_HEAD -- dev | grep -q .; then
+              git checkout FETCH_HEAD dev
+              git commit -qC "$(git log -1 --format=%H FETCH_HEAD dev)"
+            fi
+          done
+
+        # Add Haddocks
+        git add -A --force ./haddocks
+        git mv ./haddocks/* .
+        git commit -qm "Updated from ${GITHUB_SHA} via ${GITHUB_EVENT_NAME}"
+
+    - name: Push to gh-pages
+      uses: ad-m/github-push-action@v0.8.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages
+        force: true
+        directory: .

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -29,9 +29,6 @@ CABAL_OPTS=(
 
 # Generate  `doc-index.json` and `doc-index.html` per package, to assemble them later at the top level.
 HADDOCK_OPTS=(
-  --haddock-executables
-  --haddock-tests
-  --haddock-benchmarks
   --haddock-html
   --haddock-hyperlink-source
   --haddock-option "--use-unicode"


### PR DESCRIPTION
#496 broke the actual haddock generation. This time around I copied the full setup from ledger, so it should definitely work, since it does for `cardano-ledger` repo.