### PR TITLE
Disable `aarch64-darwin` build with flakes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
       "x86_64-linux"
       "x86_64-darwin"
       # "aarch64-linux" - disable these temporarily because the build is broken
-      "aarch64-darwin"
+      # "aarch64-darwin"
     ];
   in
     inputs.flake-utils.lib.eachSystem supportedSystems (


### PR DESCRIPTION
This should fix hydra CI.

After it is fixed it will also be marked as required