### PR TITLE
Add nightly ci and cancel conflicting runs

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,11 +1,36 @@
 name: Haskell CI
+# If it's a scheduled (for us: nightly) build, set the name of this run to a static value, so we can identify it easier.
+# Otherwise, replicate the default run name: either the PR title if it exists, or the commit message otherwise.
+run-name: |
+       ${{github.event_name == 'schedule' && 'Haskell CI - NIGHTLY'
+         || github.event.pull_request.title == '' && github.event.head_commit.message
+         || github.event.pull_request.title}}
 
 on:
+  push:
+    branches: [ "master", "release/**" ]
   pull_request:
     branches: [ "**" ]
-  push:
-    branches: [ "master" ]
+  schedule:
+    # "Nightly" builds: Every day at 06:00 UTC
+    - cron: '0 6 * * *'
+  # for running the workflow manually - useful for branches without PRs, for which jobs don't get ran automatically
   workflow_dispatch:
+    inputs:
+      nightly:
+        description: Run with the same settings as a nightly build
+        type: boolean
+        default: false
+
+# Cancel running workflows when a new workflow on the same PR or branch is started,
+# but put scheduled workflows into their own group
+concurrency:
+  group: ${{
+    format('{0}-{1}{2}',
+      github.workflow,
+      github.event.pull_request.number || github.ref,
+      github.event_name == 'schedule' && '-scheduled' || '')}}
+  cancel-in-progress: true
 
 jobs:
   whitespace:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.8", "9.6.4", "9.8.2", "9.10.1"]
+        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.2", "9.10.1"]
         os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         # GHC versions older than ghc-9.2 are not supported on macos-latest
         exclude:
@@ -71,7 +71,7 @@ jobs:
           - os: macos-13
             ghc: "9.2.8"
           - os: macos-13
-            ghc: "9.6.4"
+            ghc: "9.6.6"
           - os: macos-13
             ghc: "9.8.2"
           - os: macos-13
@@ -190,7 +190,7 @@ jobs:
     #     limit-access-to-actor: true
 
     - name: Cache HLS artifacts (used to speed up GitHub Codespaces bootstrapping)
-      if: runner.os == 'Linux' && (matrix.ghc == '8.10.7' || matrix.ghc == '9.6.4')
+      if: runner.os == 'Linux' && (matrix.ghc == '8.10.7' || matrix.ghc == '9.6.6')
       uses: input-output-hk/actions/cache@latest
       with:
-        ghc_version: ${{ matrix.ghc == '8.10.7' && 'ghc810' || matrix.ghc == '9.6.4' && 'ghc96' }}
+        ghc_version: ${{ matrix.ghc == '8.10.7' && 'ghc810' || matrix.ghc == '9.6.6' && 'ghc96' }}


### PR DESCRIPTION
This PR ensures we don't have duplicate CI runs for the same PR.
Also it adds nightly CI runs