### PR TITLE
Replace cryptonite library with crypton

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,9 +10,9 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 -- The hackage index-state
-index-state: 2024-06-12T11:52:25Z
+index-state: 2024-10-10T00:52:24Z
 -- The CHaP index-state
-index-state: cardano-haskell-packages 2024-06-12T11:52:25Z
+index-state: cardano-haskell-packages 2024-10-10T04:22:19Z
 
 packages:
   base-deriving-via

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -99,7 +99,7 @@ library
     , cardano-binary >= 1.6
     , cardano-mempool
     , cardano-strict-containers
-    , cryptonite
+    , crypton
     , deepseq
     , heapwords
     , io-classes >= 1.4.1

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Keccak256.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Keccak256.hs
@@ -9,7 +9,7 @@ module Cardano.Crypto.Hash.Keccak256
 where
 
 import Cardano.Crypto.Hash.Class
-import qualified "cryptonite" Crypto.Hash as H
+import qualified "crypton" Crypto.Hash as H
 import qualified Data.ByteArray as BA
 
 data Keccak256

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/RIPEMD160.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/RIPEMD160.hs
@@ -9,7 +9,7 @@ module Cardano.Crypto.Hash.RIPEMD160
   where
 
 import Cardano.Crypto.Hash.Class
-import qualified "cryptonite" Crypto.Hash as H
+import qualified "crypton" Crypto.Hash as H
 import qualified Data.ByteArray as BA
 
 data RIPEMD160

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/SHA3_256.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/SHA3_256.hs
@@ -9,7 +9,7 @@ module Cardano.Crypto.Hash.SHA3_256
 where
 
 import Cardano.Crypto.Hash.Class
-import qualified "cryptonite" Crypto.Hash as H
+import qualified "crypton" Crypto.Hash as H
 import qualified Data.ByteArray as BA
 
 data SHA3_256

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -70,7 +70,7 @@ library
                       , cardano-crypto-praos
                       , cborg
                       , containers
-                      , cryptonite
+                      , crypton
                       , contra-tracer ==0.1.0.1
                       , deepseq
                       , formatting

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -73,7 +73,7 @@ testSodiumHashAlgorithm
   -> TestTree
 testSodiumHashAlgorithm lock p =
   testGroup n
-    [ testProperty "sodium and cryptonite work the same" $ prop_libsodium_model @h lock Proxy
+    [ testProperty "sodium and crypton work the same" $ prop_libsodium_model @h lock Proxy
     ]
     where n = hashAlgorithmName p
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1725372492,
-        "narHash": "sha256-eQwfZIEHH5qHZQHXujgjj35dVAqSZa6EbTRWeppn1ME=",
+        "lastModified": 1728574792,
+        "narHash": "sha256-O1VRDuQLs8xNtqy+24J3NlLvCKDP8ZrhsVNV1tbSI9o=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "05c9f8fb28fde6e46d8768ce396a4482883d6bab",
+        "rev": "640a12a91bfa9ece619e20d2106346573081407b",
         "type": "github"
       },
       "original": {
@@ -226,11 +226,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1725409900,
-        "narHash": "sha256-XfSA7YyjHUfuNsCw4cE6p0kQcmrJgQq3nW36Cw/PAv0=",
+        "lastModified": 1728520067,
+        "narHash": "sha256-hM44JtZhnSKRzf6rJkZLPyAYHFMmysdZz1gLA+0Kctk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d86e544dec33ce5fb0ad3981be91074d397b700d",
+        "rev": "06fc3131daf5fcd3db12429d0c62e6c1db97eb5a",
         "type": "github"
       },
       "original": {
@@ -706,11 +706,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1720122915,
-        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "lastModified": 1726447378,
+        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
         "type": "github"
       },
       "original": {
@@ -754,11 +754,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1720181791,
-        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
+        "lastModified": 1726583932,
+        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
+        "rev": "658e7223191d2598641d50ee4e898126768fe847",
         "type": "github"
       },
       "original": {
@@ -889,11 +889,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1725408838,
-        "narHash": "sha256-tHw95xcMElCqI6xOLmdTAEvQ0/4IS7WBZc+RF7HT/uk=",
+        "lastModified": 1728519053,
+        "narHash": "sha256-eLqU1oYOInJgc0bVzPhkYzFZ3C/naHTY8C6gzgGz3Jo=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "2ab3b5a823933ef199a289fbf39bbf0da0023100",
+        "rev": "fbf28874c9c0e75d99f97e81057097f018d37574",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Replace cryptonite (which is deprecated) library with crypton. The later is a drop in replacement.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
