### PR TITLE
UnsoundPureKES and DirectSerialise API

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -20,6 +20,9 @@ solidified. Ask @lehins if backport is needed.
   [#404](https://github.com/input-output-hk/cardano-base/pull/404)
 * Restructuring of libsodium bindings and related APIs:
   [#404](https://github.com/input-output-hk/cardano-base/pull/404)
+* Re-introduction of non-mlocked KES implementations to support a smoother
+  migration path:
+  [#504](https://github.com/IntersectMBO/cardano-base/pull/504)
 
 ## 2.1.0.2
 

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -39,6 +39,7 @@ library
   import:            base, project-config
   hs-source-dirs:    src
   exposed-modules:
+    Cardano.Crypto.DirectSerialise
     Cardano.Crypto.DSIGN
     Cardano.Crypto.DSIGN.Class
     Cardano.Crypto.DSIGN.Ed25519

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -413,4 +413,4 @@ instance DirectDeserialise (VerKeyDSIGN Ed25519DSIGN) where
       pull
         (castPtr ptr)
         (fromIntegral $ sizeVerKeyDSIGN (Proxy @Ed25519DSIGN))
-    return $! VerKeyEd25519DSIGN $! psb
+    return $! VerKeyEd25519DSIGN psb

--- a/cardano-crypto-class/src/Cardano/Crypto/DirectSerialise.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DirectSerialise.hs
@@ -1,0 +1,41 @@
+-- | Direct (de-)serialisation to / from raw memory.
+--
+-- The purpose of the typeclasses in this module is to abstract over data
+-- structures that can expose the data they store as one or more raw 'Ptr's,
+-- without any additional memory copying or conversion to intermediate data
+-- structures.
+--
+-- This is useful for transmitting data like KES SignKeys over a socket
+-- connection: by accessing the memory directly and copying it into or out of
+-- a file descriptor, without going through an intermediate @ByteString@
+-- representation (or other data structure that resides in the GHC heap), we
+-- can more easily assure that the data is never written to disk, including
+-- swap, which is an important requirement for KES.
+module Cardano.Crypto.DirectSerialise
+where
+
+import Foreign.Ptr
+import Foreign.C.Types
+import Control.Monad.Class.MonadThrow (MonadThrow)
+import Control.Monad.Class.MonadST (MonadST)
+
+-- | Direct deserialization from raw memory.
+--
+-- @directDeserialise f@ should allocate a new value of type 'a', and
+-- call @f@ with a pointer to the raw memory to be filled. @f@ may be called
+-- multiple times, for data structures that store their data in multiple
+-- non-contiguous blocks of memory.
+--
+-- The order in which memory blocks are visited matters.
+class DirectDeserialise a where
+  directDeserialise :: (MonadST m, MonadThrow m) => (Ptr CChar -> CSize -> m ()) -> m a
+
+-- | Direct serialization to raw memory.
+--
+-- @directSerialise f x@ should call @f@ to expose the raw memory underyling
+-- @x@. For data types that store their data in multiple non-contiguous blocks
+-- of memory, @f@ may be called multiple times, once for each block.
+--
+-- The order in which memory blocks are visited matters.
+class DirectSerialise a where
+  directSerialise :: (MonadST m, MonadThrow m) => (Ptr CChar -> CSize -> m ()) -> a -> m ()

--- a/cardano-crypto-class/src/Cardano/Crypto/DirectSerialise.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DirectSerialise.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- | Direct (de-)serialisation to / from raw memory.
 --
 -- The purpose of the typeclasses in this module is to abstract over data
@@ -16,8 +18,25 @@ where
 
 import Foreign.Ptr
 import Foreign.C.Types
+import Control.Monad (when)
 import Control.Monad.Class.MonadThrow (MonadThrow)
-import Control.Monad.Class.MonadST (MonadST)
+import Control.Monad.Class.MonadST (MonadST, stToIO)
+import Control.Exception
+import Data.STRef (newSTRef, readSTRef, writeSTRef)
+import Cardano.Crypto.Libsodium.Memory (copyMem)
+
+data SizeCheckException =
+  SizeCheckException
+    { expectedSize :: Int
+    , actualSize :: Int
+    }
+    deriving (Show)
+
+instance Exception SizeCheckException where
+
+sizeCheckFailed :: Int -> Int -> m ()
+sizeCheckFailed ex ac =
+  throw $ SizeCheckException ex ac
 
 -- | Direct deserialization from raw memory.
 --
@@ -39,3 +58,138 @@ class DirectDeserialise a where
 -- The order in which memory blocks are visited matters.
 class DirectSerialise a where
   directSerialise :: (MonadST m, MonadThrow m) => (Ptr CChar -> CSize -> m ()) -> a -> m ()
+
+-- | Helper function for bounds-checked serialization.
+-- Verifies that no more than the maximum number of bytes are written, and
+-- returns the actual number of bytes written.
+directSerialiseTo :: forall m a.
+                     DirectSerialise a
+                  => MonadST m
+                  => MonadThrow m
+                  => (Int -> Ptr CChar -> CSize -> m ())
+                  -> Int
+                  -> a
+                  -> m Int
+directSerialiseTo writeBytes dstsize val = do
+  posRef <- stToIO $ newSTRef 0
+  let pusher :: Ptr CChar -> CSize -> m ()
+      pusher src srcsize = do
+        pos <- stToIO $ readSTRef posRef
+        let pos' = pos + fromIntegral srcsize
+        when (pos' > dstsize) $
+            sizeCheckFailed (dstsize - pos) (pos' - pos)
+        writeBytes pos src (fromIntegral srcsize)
+        stToIO $ writeSTRef posRef pos'
+  directSerialise pusher val
+  stToIO $ readSTRef posRef
+
+-- | Helper function for size-checked serialization.
+-- Verifies that exactly the specified number of bytes are written.
+directSerialiseToChecked :: forall m a.
+                            DirectSerialise a
+                         => MonadST m
+                         => MonadThrow m
+                         => (Int -> Ptr CChar -> CSize -> m ())
+                         -> Int
+                         -> a
+                         -> m ()
+directSerialiseToChecked writeBytes dstsize val = do
+  bytesWritten <- directSerialiseTo writeBytes dstsize val
+  when (bytesWritten /= dstsize) $
+    sizeCheckFailed dstsize bytesWritten
+
+-- | Helper function for the common use case of serializing to an in-memory
+-- buffer.
+-- Verifies that no more than the maximum number of bytes are written, and
+-- returns the actual number of bytes written.
+directSerialiseBuf :: forall m a.
+                          DirectSerialise a
+                       => MonadST m
+                       => MonadThrow m
+                       => Ptr CChar
+                       -> Int
+                       -> a
+                       -> m Int
+directSerialiseBuf dst =
+  directSerialiseTo (copyMem . plusPtr dst)
+
+-- | Helper function for size-checked serialization to an in-memory buffer.
+-- Verifies that exactly the specified number of bytes are written.
+directSerialiseBufChecked :: forall m a.
+                            DirectSerialise a
+                         => MonadST m
+                         => MonadThrow m
+                         => Ptr CChar
+                         -> Int
+                         -> a
+                         -> m ()
+directSerialiseBufChecked buf dstsize val = do
+  bytesWritten <- directSerialiseBuf buf dstsize val
+  when (bytesWritten /= dstsize) $
+    sizeCheckFailed dstsize bytesWritten
+
+-- | Helper function for size-checked deserialization.
+-- Verifies that no more than the maximum number of bytes are read, and returns
+-- the actual number of bytes read.
+directDeserialiseFrom :: forall m a.
+                            DirectDeserialise a
+                         => MonadST m
+                         => MonadThrow m
+                         => (Int -> Ptr CChar -> CSize -> m ())
+                         -> Int
+                         -> m (a, Int)
+directDeserialiseFrom readBytes srcsize = do
+  posRef <- stToIO $ newSTRef 0
+  let puller :: Ptr CChar -> CSize -> m ()
+      puller dst dstsize = do
+        pos <- stToIO $ readSTRef posRef
+        let pos' = pos + fromIntegral dstsize
+        when (pos' > srcsize) $
+            sizeCheckFailed (srcsize - pos) (pos' - pos)
+        readBytes pos dst (fromIntegral dstsize)
+        stToIO $ writeSTRef posRef pos'
+  (,) <$> directDeserialise puller <*> stToIO (readSTRef posRef)
+
+-- | Helper function for size-checked deserialization.
+-- Verifies that exactly the specified number of bytes are read.
+directDeserialiseFromChecked :: forall m a.
+                            DirectDeserialise a
+                         => MonadST m
+                         => MonadThrow m
+                         => (Int -> Ptr CChar -> CSize -> m ())
+                         -> Int
+                         -> m a
+directDeserialiseFromChecked readBytes srcsize = do
+  (r, bytesRead) <- directDeserialiseFrom readBytes srcsize
+  when (bytesRead /= srcsize) $
+    sizeCheckFailed srcsize bytesRead
+  return r
+
+-- | Helper function for the common use case of deserializing from an in-memory
+-- buffer.
+-- Verifies that no more than the maximum number of bytes are read, and returns
+-- the actual number of bytes read.
+directDeserialiseBuf :: forall m a.
+                            DirectDeserialise a
+                         => MonadST m
+                         => MonadThrow m
+                         => Ptr CChar
+                         -> Int
+                         -> m (a, Int)
+directDeserialiseBuf src =
+  directDeserialiseFrom (\pos dst -> copyMem dst (plusPtr src pos))
+
+-- | Helper function for size-checked deserialization from an in-memory buffer.
+-- Verifies that exactly the specified number of bytes are read.
+directDeserialiseBufChecked :: forall m a.
+                            DirectDeserialise a
+                         => MonadST m
+                         => MonadThrow m
+                         => Ptr CChar
+                         -> Int
+                         -> m a
+directDeserialiseBufChecked buf srcsize = do
+  (r, bytesRead) <- directDeserialiseBuf buf srcsize
+  when (bytesRead /= srcsize) $
+    sizeCheckFailed srcsize bytesRead
+  return r

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -60,7 +60,7 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash.Class
 import Cardano.Crypto.DSIGN.Class as DSIGN
 import Cardano.Crypto.KES.Class
-
+import Cardano.Crypto.DirectSerialise
 
 -- | A standard signature scheme is a forward-secure signature scheme with a
 -- single time period.
@@ -227,3 +227,19 @@ instance (DSIGNMAlgorithm d, KnownNat (SizeSigKES (CompactSingleKES d))) => From
 slice :: Word -> Word -> ByteString -> ByteString
 slice offset size = BS.take (fromIntegral size)
                   . BS.drop (fromIntegral offset)
+
+--
+-- Direct ser/deser
+--
+
+instance (DirectSerialise (SignKeyDSIGNM d)) => DirectSerialise (SignKeyKES (CompactSingleKES d)) where
+  directSerialise push (SignKeyCompactSingleKES sk) = directSerialise push sk
+
+instance (DirectDeserialise (SignKeyDSIGNM d)) => DirectDeserialise (SignKeyKES (CompactSingleKES d)) where
+  directDeserialise pull = SignKeyCompactSingleKES <$!> directDeserialise pull
+
+instance (DirectSerialise (VerKeyDSIGN d)) => DirectSerialise (VerKeyKES (CompactSingleKES d)) where
+  directSerialise push (VerKeyCompactSingleKES sk) = directSerialise push sk
+
+instance (DirectDeserialise (VerKeyDSIGN d)) => DirectDeserialise (VerKeyKES (CompactSingleKES d)) where
+  directDeserialise pull = VerKeyCompactSingleKES <$!> directDeserialise pull

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -192,9 +192,8 @@ instance ( KESAlgorithm (CompactSingleKES d)
     unsoundPureDeriveVerKeyKES (UnsoundPureSignKeyCompactSingleKES v) =
       VerKeyCompactSingleKES $! deriveVerKeyDSIGN v
 
-    unsoundPureSignKeyKESToSoundSignKeyKES (UnsoundPureSignKeyCompactSingleKES sk) =
-      maybe (error "unsoundPureSignKeyKESToSoundSignKeyKES: deserialisation failure") (return . SignKeyCompactSingleKES)
-      =<< (rawDeserialiseSignKeyDSIGNM . rawSerialiseSignKeyDSIGN $ sk)
+    unsoundPureSignKeyKESToSoundSignKeyKES =
+      unsoundPureSignKeyKESToSoundSignKeyKESViaSer
 
     rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeyCompactSingleKES sk) =
       rawSerialiseSignKeyDSIGN sk

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -97,6 +97,7 @@ import           Cardano.Crypto.Hash.Class
 import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.KES.CompactSingle (CompactSingleKES)
 import           Cardano.Crypto.Util
+import           Cardano.Crypto.Seed
 import           Cardano.Crypto.Libsodium.MLockedSeed
 import           Cardano.Crypto.Libsodium
 import           Cardano.Crypto.Libsodium.Memory
@@ -467,6 +468,133 @@ instance ( OptimizedKESAlgorithm d
          )
       => FromCBOR (SigKES (CompactSumKES h d)) where
   fromCBOR = decodeSigKES
+
+
+--
+-- Unsound pure KES API
+--
+instance ( KESAlgorithm (CompactSumKES h d)
+         , HashAlgorithm h
+         , UnsoundPureKESAlgorithm d
+         )
+         => UnsoundPureKESAlgorithm (CompactSumKES h d) where
+    data UnsoundPureSignKeyKES (CompactSumKES h d) =
+           UnsoundPureSignKeyCompactSumKES !(UnsoundPureSignKeyKES d)
+                         !Seed
+                         !(VerKeyKES d)
+                         !(VerKeyKES d)
+           deriving (Generic)
+
+    unsoundPureSignKES ctxt t a (UnsoundPureSignKeyCompactSumKES sk _r_1 vk_0 vk_1) =
+        SigCompactSumKES sigma vk_other
+      where
+        (sigma, vk_other)
+          | t < _T    = (unsoundPureSignKES ctxt  t       a sk, vk_1)
+          | otherwise = (unsoundPureSignKES ctxt (t - _T) a sk, vk_0)
+
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    unsoundPureUpdateKES ctx (UnsoundPureSignKeyCompactSumKES sk r_1 vk_0 vk_1) t
+      | t+1 <  _T = do
+                        sk' <- unsoundPureUpdateKES ctx sk t
+                        let r_1' = r_1
+                        return $! UnsoundPureSignKeyCompactSumKES sk' r_1' vk_0 vk_1
+      | t+1 == _T = do
+                        let sk' = unsoundPureGenKeyKES r_1
+                        let r_1' = mkSeedFromBytes (BS.replicate (fromIntegral (seedSizeKES (Proxy @d))) 0)
+                        return $! UnsoundPureSignKeyCompactSumKES sk' r_1' vk_0 vk_1
+      | otherwise = do
+                        sk' <- unsoundPureUpdateKES ctx sk (t - _T)
+                        let r_1' = r_1
+                        return $! UnsoundPureSignKeyCompactSumKES sk' r_1' vk_0 vk_1
+      where
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    --
+    -- Key generation
+    --
+
+    unsoundPureGenKeyKES r =
+      let r0 = mkSeedFromBytes $ digest (Proxy @h) (BS.cons 1 $ getSeedBytes r)
+          r1 = mkSeedFromBytes $ digest (Proxy @h) (BS.cons 2 $ getSeedBytes r)
+          sk_0 = unsoundPureGenKeyKES r0
+          vk_0 = unsoundPureDeriveVerKeyKES sk_0
+          sk_1 = unsoundPureGenKeyKES r1
+          vk_1 = unsoundPureDeriveVerKeyKES sk_1
+      in UnsoundPureSignKeyCompactSumKES sk_0 r1 vk_0 vk_1
+
+    unsoundPureDeriveVerKeyKES (UnsoundPureSignKeyCompactSumKES _ _ vk_0 vk_1) =
+      VerKeyCompactSumKES (hashPairOfVKeys (vk_0, vk_1))
+
+    unsoundPureSignKeyKESToSoundSignKeyKES (UnsoundPureSignKeyCompactSumKES sk r_1 vk_0 vk_1) =
+      SignKeyCompactSumKES
+        <$> unsoundPureSignKeyKESToSoundSignKeyKES sk
+        <*> (fmap MLockedSeed . mlsbFromByteString . getSeedBytes $ r_1)
+        <*> pure vk_0
+        <*> pure vk_1
+
+    rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeyCompactSumKES sk r_1 vk_0 vk_1) =
+      let ssk = rawSerialiseUnsoundPureSignKeyKES sk
+          sr1 = getSeedBytes r_1
+      in mconcat
+          [ ssk
+          , sr1
+          , rawSerialiseVerKeyKES vk_0
+          , rawSerialiseVerKeyKES vk_1
+          ]
+
+    rawDeserialiseUnsoundPureSignKeyKES b = do
+        guard (BS.length b == fromIntegral size_total)
+        sk   <- rawDeserialiseUnsoundPureSignKeyKES b_sk
+        let r = mkSeedFromBytes b_r
+        vk_0 <- rawDeserialiseVerKeyKES  b_vk0
+        vk_1 <- rawDeserialiseVerKeyKES  b_vk1
+        return (UnsoundPureSignKeyCompactSumKES sk r vk_0 vk_1)
+      where
+        b_sk  = slice off_sk  size_sk b
+        b_r   = slice off_r   size_r  b
+        b_vk0 = slice off_vk0 size_vk b
+        b_vk1 = slice off_vk1 size_vk b
+
+        size_sk    = sizeSignKeyKES (Proxy :: Proxy d)
+        size_r     = seedSizeKES    (Proxy :: Proxy d)
+        size_vk    = sizeVerKeyKES  (Proxy :: Proxy d)
+        size_total = sizeSignKeyKES (Proxy :: Proxy (CompactSumKES h d))
+
+        off_sk     = 0 :: Word
+        off_r      = size_sk
+        off_vk0    = off_r + size_r
+        off_vk1    = off_vk0 + size_vk
+
+--
+-- UnsoundPureSignKey instances
+--
+
+deriving instance (KESAlgorithm d, Show (UnsoundPureSignKeyKES d)) => Show (UnsoundPureSignKeyKES (CompactSumKES h d))
+deriving instance (KESAlgorithm d, Eq (UnsoundPureSignKeyKES d)) => Eq   (UnsoundPureSignKeyKES (CompactSumKES h d))
+
+instance ( SizeHash h ~ SeedSizeKES d
+         , OptimizedKESAlgorithm d
+         , UnsoundPureKESAlgorithm d
+         , SodiumHashAlgorithm h
+         , KnownNat (SizeVerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSignKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSigKES (CompactSumKES h d))
+         ) => ToCBOR (UnsoundPureSignKeyKES (CompactSumKES h d)) where
+  toCBOR = encodeUnsoundPureSignKeyKES
+  encodedSizeExpr _size _skProxy = encodedSignKeyKESSizeExpr (Proxy :: Proxy (SignKeyKES (CompactSumKES h d)))
+
+instance ( SizeHash h ~ SeedSizeKES d
+         , OptimizedKESAlgorithm d
+         , UnsoundPureKESAlgorithm d
+         , SodiumHashAlgorithm h
+         , KnownNat (SizeVerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSignKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSigKES (CompactSumKES h d))
+         ) => FromCBOR (UnsoundPureSignKeyKES (CompactSumKES h d)) where
+  fromCBOR = decodeUnsoundPureSignKeyKES
+
+instance (NoThunks (UnsoundPureSignKeyKES d), KESAlgorithm d) => NoThunks (UnsoundPureSignKeyKES  (CompactSumKES h d))
 
 
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -86,7 +87,7 @@ module Cardano.Crypto.KES.CompactSum (
 import           Data.Proxy (Proxy(..))
 import           GHC.Generics (Generic)
 import qualified Data.ByteString as BS
-import           Control.Monad (guard)
+import           Control.Monad (guard, (<$!>))
 import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
@@ -97,10 +98,14 @@ import           Cardano.Crypto.KES.CompactSingle (CompactSingleKES)
 import           Cardano.Crypto.Util
 import           Cardano.Crypto.Libsodium.MLockedSeed
 import           Cardano.Crypto.Libsodium
+import           Cardano.Crypto.Libsodium.Memory
+import           Cardano.Crypto.DirectSerialise
+
 import           Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import           Control.Monad.Trans (lift)
 import           Control.DeepSeq (NFData (..))
 import           GHC.TypeLits (KnownNat, type (+), type (*))
+import           Foreign.Ptr (castPtr)
 
 -- | A 2^0 period KES
 type CompactSum0KES d   = CompactSingleKES d
@@ -461,3 +466,51 @@ instance ( OptimizedKESAlgorithm d
          )
       => FromCBOR (SigKES (CompactSumKES h d)) where
   fromCBOR = decodeSigKES
+
+
+--
+-- Direct ser/deser
+--
+
+instance ( DirectSerialise (SignKeyKES d)
+         , DirectSerialise (VerKeyKES d)
+         , KESAlgorithm d
+         ) => DirectSerialise (SignKeyKES (CompactSumKES h d)) where
+  directSerialise push (SignKeyCompactSumKES sk r vk0 vk1) = do
+    directSerialise push sk
+    mlockedSeedUseAsCPtr r $ \ptr ->
+      push (castPtr ptr) (fromIntegral $ seedSizeKES (Proxy :: Proxy d))
+    directSerialise push vk0
+    directSerialise push vk1
+
+instance ( DirectDeserialise (SignKeyKES d)
+         , DirectDeserialise (VerKeyKES d)
+         , KESAlgorithm d
+         ) => DirectDeserialise (SignKeyKES (CompactSumKES h d)) where
+  directDeserialise pull = do
+    sk <- directDeserialise pull
+
+    r <- mlockedSeedNew
+    mlockedSeedUseAsCPtr r $ \ptr ->
+      pull (castPtr ptr) (fromIntegral $ seedSizeKES (Proxy :: Proxy d))
+
+    vk0 <- directDeserialise pull
+    vk1 <- directDeserialise pull
+
+    return $! SignKeyCompactSumKES sk r vk0 vk1
+
+
+instance DirectSerialise (VerKeyKES (CompactSumKES h d)) where
+  directSerialise push (VerKeyCompactSumKES h) =
+    unpackByteStringCStringLen (hashToBytes h) $ \(ptr, len) ->
+      push (castPtr ptr) (fromIntegral len)
+
+instance (HashAlgorithm h)
+         => DirectDeserialise (VerKeyKES (CompactSumKES h d)) where
+  directDeserialise pull = do
+    let len :: Num a => a
+        len = fromIntegral $ sizeHash (Proxy @h)
+    allocaBytes len $ \ptr -> do
+      pull ptr len
+      bs <- packByteStringCStringLen (ptr, len)
+      maybe (error "Invalid hash") return $! VerKeyCompactSumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -607,8 +607,7 @@ instance ( DirectSerialise (SignKeyKES d)
          ) => DirectSerialise (SignKeyKES (CompactSumKES h d)) where
   directSerialise push (SignKeyCompactSumKES sk r vk0 vk1) = do
     directSerialise push sk
-    mlockedSeedUseAsCPtr r $ \ptr ->
-      push (castPtr ptr) (fromIntegral $ seedSizeKES (Proxy :: Proxy d))
+    directSerialise push r
     directSerialise push vk0
     directSerialise push vk1
 
@@ -618,11 +617,7 @@ instance ( DirectDeserialise (SignKeyKES d)
          ) => DirectDeserialise (SignKeyKES (CompactSumKES h d)) where
   directDeserialise pull = do
     sk <- directDeserialise pull
-
-    r <- mlockedSeedNew
-    mlockedSeedUseAsCPtr r $ \ptr ->
-      pull (castPtr ptr) (fromIntegral $ seedSizeKES (Proxy :: Proxy d))
-
+    r <- directDeserialise pull
     vk0 <- directDeserialise pull
     vk1 <- directDeserialise pull
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -24,6 +24,8 @@ import Data.Proxy (Proxy(..))
 import GHC.Generics (Generic)
 import GHC.TypeNats (Nat, KnownNat, natVal)
 import NoThunks.Class (NoThunks)
+import qualified Data.ByteString.Internal as BS
+import Foreign.Ptr (castPtr)
 
 import Control.Exception (assert)
 
@@ -39,8 +41,9 @@ import Cardano.Crypto.Libsodium
   )
 import Cardano.Crypto.Libsodium.Memory
   ( unpackByteStringCStringLen
-  , packByteStringCStringLen
-  , allocaBytes
+  , ForeignPtr (..)
+  , mallocForeignPtrBytes
+  , withForeignPtr
   )
 import Cardano.Crypto.DirectSerialise
 
@@ -210,9 +213,10 @@ instance (KnownNat t) => DirectSerialise (SignKeyKES (MockKES t)) where
 instance (KnownNat t) => DirectDeserialise (SignKeyKES (MockKES t)) where
   directDeserialise pull = do
     let len = fromIntegral $ sizeSignKeyKES (Proxy @(MockKES t))
-    bs <- allocaBytes len $ \cstr -> do
-        pull cstr (fromIntegral len)
-        packByteStringCStringLen (cstr, len)
+    fptr <- mallocForeignPtrBytes len
+    withForeignPtr fptr $ \ptr ->
+        pull (castPtr ptr) (fromIntegral len)
+    let bs = BS.fromForeignPtr (unsafeRawForeignPtr fptr) 0 len
     maybe (error "directDeserialise @(SignKeyKES (MockKES t))") return $
         rawDeserialiseSignKeyMockKES bs
 
@@ -224,8 +228,9 @@ instance (KnownNat t) => DirectSerialise (VerKeyKES (MockKES t)) where
 instance (KnownNat t) => DirectDeserialise (VerKeyKES (MockKES t)) where
   directDeserialise pull = do
     let len = fromIntegral $ sizeVerKeyKES (Proxy @(MockKES t))
-    bs <- allocaBytes len $ \cstr -> do
-        pull cstr (fromIntegral len)
-        packByteStringCStringLen (cstr, len)
+    fptr <- mallocForeignPtrBytes len
+    withForeignPtr fptr $ \ptr ->
+        pull (castPtr ptr) (fromIntegral len)
+    let bs = BS.fromForeignPtr (unsafeRawForeignPtr fptr) 0 len
     maybe (error "directDeserialise @(VerKeyKES (MockKES t))") return $
         rawDeserialiseVerKeyKES bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -161,7 +161,7 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     --
 
     genKeyKESWith _allocator seed = do
-        seedBS <- mlsbToByteString . mlockedSeedMLSB $ seed
+        seedBS <- mlsbToByteString $ mlockedSeedMLSB seed
         let vk = VerKeyMockKES (runMonadRandomWithSeed (mkSeedFromBytes seedBS) getRandomWord64)
         return $! SignKeyMockKES vk 0
 
@@ -273,9 +273,9 @@ instance (KnownNat t) => DirectDeserialise (SignKeyKES (MockKES t)) where
         rawDeserialiseSignKeyMockKES bs
 
 instance (KnownNat t) => DirectSerialise (VerKeyKES (MockKES t)) where
-  directSerialise put sk = do
+  directSerialise push sk = do
     let bs = rawSerialiseVerKeyKES sk
-    unpackByteStringCStringLen bs $ \(cstr, len) -> put cstr (fromIntegral len)
+    unpackByteStringCStringLen bs $ \(cstr, len) -> push cstr (fromIntegral len)
 
 instance (KnownNat t) => DirectDeserialise (VerKeyKES (MockKES t)) where
   directDeserialise pull = do

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -65,3 +65,15 @@ instance KESAlgorithm NeverKES where
 instance UnsoundKESAlgorithm NeverKES where
   rawSerialiseSignKeyKES _ = return mempty
   rawDeserialiseSignKeyKESWith _ _ = return $ Just NeverUsedSignKeyKES
+
+instance UnsoundPureKESAlgorithm NeverKES where
+  data UnsoundPureSignKeyKES NeverKES = NeverUsedUnsoundPureSignKeyKES
+      deriving (Show, Eq, Generic, NoThunks)
+
+  unsoundPureSignKES = error "KES not available"
+  unsoundPureGenKeyKES _ = NeverUsedUnsoundPureSignKeyKES
+  unsoundPureDeriveVerKeyKES _ = NeverUsedVerKeyKES
+  unsoundPureUpdateKES _ = error "KES not available"
+  unsoundPureSignKeyKESToSoundSignKeyKES _ = return NeverUsedSignKeyKES
+  rawSerialiseUnsoundPureSignKeyKES _ = mempty
+  rawDeserialiseUnsoundPureSignKeyKES _ = Just NeverUsedUnsoundPureSignKeyKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -22,6 +22,7 @@ module Cardano.Crypto.KES.Simple
   ( SimpleKES
   , SigKES (..)
   , SignKeyKES (SignKeySimpleKES, ThunkySignKeySimpleKES)
+  , UnsoundPureSignKeyKES (UnsoundPureSignKeySimpleKES, UnsoundPureThunkySignKeySimpleKES)
   )
 where
 
@@ -43,8 +44,10 @@ import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.Libsodium.MLockedSeed
 import           Cardano.Crypto.Libsodium.MLockedBytes
 import           Cardano.Crypto.Util
+import           Cardano.Crypto.Seed
 import           Cardano.Crypto.DirectSerialise
 import           Data.Unit.Strict (forceElemsToWHNF)
+import           Data.Maybe (fromMaybe)
 
 data SimpleKES d (t :: Nat)
 
@@ -68,6 +71,14 @@ pattern SignKeySimpleKES v <- ThunkySignKeySimpleKES v
     SignKeySimpleKES v = ThunkySignKeySimpleKES (forceElemsToWHNF v)
 
 {-# COMPLETE SignKeySimpleKES #-}
+
+-- | See 'VerKeySimpleKES'.
+pattern UnsoundPureSignKeySimpleKES :: Vector (SignKeyDSIGN d) -> UnsoundPureSignKeyKES (SimpleKES d t)
+pattern UnsoundPureSignKeySimpleKES v <- UnsoundPureThunkySignKeySimpleKES v
+  where
+    UnsoundPureSignKeySimpleKES v = UnsoundPureThunkySignKeySimpleKES (forceElemsToWHNF v)
+
+{-# COMPLETE UnsoundPureSignKeySimpleKES #-}
 
 instance ( DSIGNMAlgorithm d
          , KnownNat t
@@ -177,6 +188,64 @@ instance ( DSIGNMAlgorithm d
     forgetSignKeyKESWith allocator (SignKeySimpleKES sks) =
       Vec.mapM_ (forgetSignKeyDSIGNMWith allocator) sks
 
+instance ( KESAlgorithm (SimpleKES d t)
+         , KnownNat t
+         , DSIGNAlgorithm d
+         , UnsoundDSIGNMAlgorithm d
+         )
+         => UnsoundPureKESAlgorithm (SimpleKES d t) where
+
+    newtype UnsoundPureSignKeyKES (SimpleKES d t) =
+              UnsoundPureThunkySignKeySimpleKES (Vector (SignKeyDSIGN d))
+        deriving Generic
+
+    unsoundPureGenKeyKES seed =
+      let seedSize = fromIntegral (seedSizeDSIGN (Proxy :: Proxy d))
+          duration = fromIntegral (natVal (Proxy @t))
+          seedChunk t =
+            mkSeedFromBytes (BS.take seedSize . BS.drop (seedSize * t) $ getSeedBytes seed)
+      in
+        UnsoundPureSignKeySimpleKES $
+          Vec.generate duration (\t ->
+            genKeyDSIGN (seedChunk t))
+
+    unsoundPureSignKES ctxt j a (UnsoundPureSignKeySimpleKES sks) =
+        case sks !? fromIntegral j of
+          Nothing -> error ("SimpleKES.unsoundPureSignKES: period out of range " ++ show j)
+          Just sk -> SigSimpleKES $! (signDSIGN ctxt a $! sk)
+
+    unsoundPureUpdateKES _ (UnsoundPureThunkySignKeySimpleKES sk) t
+      | t+1 < fromIntegral (natVal (Proxy @t))
+      = Just $! UnsoundPureThunkySignKeySimpleKES sk
+      | otherwise
+      = Nothing
+
+    unsoundPureDeriveVerKeyKES (UnsoundPureSignKeySimpleKES sks) =
+      VerKeySimpleKES $! Vec.map deriveVerKeyDSIGN sks
+
+    unsoundPureSignKeyKESToSoundSignKeyKES (UnsoundPureThunkySignKeySimpleKES sks) = do
+      SignKeySimpleKES <$> mapM convertSK sks
+      where
+        convertSK = fmap (fromMaybe (error "unsoundPureSignKeyKESToSoundSignKeyKES: deserialisation failed"))
+                      . rawDeserialiseSignKeyDSIGNM
+                      . rawSerialiseSignKeyDSIGN
+
+    rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeySimpleKES sks) =
+        BS.concat $! map rawSerialiseSignKeyDSIGN (Vec.toList sks)
+
+
+    rawDeserialiseUnsoundPureSignKeyKES bs
+      | let duration = fromIntegral (natVal (Proxy :: Proxy t))
+            sizeKey  = fromIntegral (sizeSignKeyDSIGN (Proxy :: Proxy d))
+            skbs     = splitsAt (replicate duration sizeKey) bs
+      , length skbs == duration
+      = do
+          sks <- mapM rawDeserialiseSignKeyDSIGN skbs
+          return $! UnsoundPureSignKeySimpleKES (Vec.fromList sks)
+
+      | otherwise
+      = Nothing
+
 
 
 instance ( UnsoundDSIGNMAlgorithm d, KnownNat t, KESAlgorithm (SimpleKES d t))
@@ -203,13 +272,16 @@ instance ( UnsoundDSIGNMAlgorithm d, KnownNat t, KESAlgorithm (SimpleKES d t))
 
 deriving instance DSIGNMAlgorithm d => Show (VerKeyKES (SimpleKES d t))
 deriving instance (DSIGNMAlgorithm d, Show (SignKeyDSIGNM d)) => Show (SignKeyKES (SimpleKES d t))
+deriving instance (DSIGNMAlgorithm d, Show (SignKeyDSIGNM d)) => Show (UnsoundPureSignKeyKES (SimpleKES d t))
 deriving instance DSIGNMAlgorithm d => Show (SigKES (SimpleKES d t))
 
-deriving instance DSIGNMAlgorithm d => Eq   (VerKeyKES (SimpleKES d t))
-deriving instance DSIGNMAlgorithm d => Eq   (SigKES (SimpleKES d t))
+deriving instance DSIGNMAlgorithm d => Eq (VerKeyKES (SimpleKES d t))
+deriving instance DSIGNMAlgorithm d => Eq (SigKES (SimpleKES d t))
+deriving instance Eq (SignKeyDSIGN d) => Eq (UnsoundPureSignKeyKES (SimpleKES d t))
 
 instance DSIGNMAlgorithm d => NoThunks (SigKES     (SimpleKES d t))
 instance DSIGNMAlgorithm d => NoThunks (SignKeyKES (SimpleKES d t))
+instance DSIGNMAlgorithm d => NoThunks (UnsoundPureSignKeyKES (SimpleKES d t))
 instance DSIGNMAlgorithm d => NoThunks (VerKeyKES  (SimpleKES d t))
 
 instance ( DSIGNMAlgorithm d

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -43,6 +43,7 @@ import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.Libsodium.MLockedSeed
 import           Cardano.Crypto.Libsodium.MLockedBytes
 import           Cardano.Crypto.Util
+import           Cardano.Crypto.DirectSerialise
 import           Data.Unit.Strict (forceElemsToWHNF)
 
 data SimpleKES d (t :: Nat)
@@ -249,3 +250,22 @@ instance (DSIGNMAlgorithm d
       => FromCBOR (SigKES (SimpleKES d t)) where
   fromCBOR = decodeSigKES
 
+instance (DirectSerialise (VerKeyDSIGN d)) => DirectSerialise (VerKeyKES (SimpleKES d t)) where
+  directSerialise push (VerKeySimpleKES vks) =
+    mapM_ (directSerialise push) vks
+
+instance (DirectDeserialise (VerKeyDSIGN d), KnownNat t) => DirectDeserialise (VerKeyKES (SimpleKES d t)) where
+  directDeserialise pull = do
+    let duration = fromIntegral (natVal (Proxy :: Proxy t))
+    vks <- Vec.replicateM duration (directDeserialise pull)
+    return $! VerKeySimpleKES $! vks
+
+instance (DirectSerialise (SignKeyDSIGNM d)) => DirectSerialise (SignKeyKES (SimpleKES d t)) where
+  directSerialise push (SignKeySimpleKES sks) =
+    mapM_ (directSerialise push) sks
+
+instance (DirectDeserialise (SignKeyDSIGNM d), KnownNat t) => DirectDeserialise (SignKeyKES (SimpleKES d t)) where
+  directDeserialise pull = do
+    let duration = fromIntegral (natVal (Proxy :: Proxy t))
+    sks <- Vec.replicateM duration (directDeserialise pull)
+    return $! SignKeySimpleKES $! sks

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -140,6 +140,38 @@ instance (DSIGNMAlgorithm d) => KESAlgorithm (SingleKES d) where
     forgetSignKeyKESWith allocator (SignKeySingleKES v) =
       forgetSignKeyDSIGNMWith allocator v
 
+instance ( KESAlgorithm (SingleKES d)
+         , UnsoundDSIGNMAlgorithm d
+         )
+         => UnsoundPureKESAlgorithm (SingleKES d) where
+    newtype UnsoundPureSignKeyKES (SingleKES d) = UnsoundPureSignKeySingleKES (SignKeyDSIGN d)
+      deriving (Generic)
+
+    unsoundPureSignKES ctxt t a (UnsoundPureSignKeySingleKES sk) =
+        assert (t == 0) $!
+        SigSingleKES $! signDSIGN ctxt a sk
+
+    unsoundPureUpdateKES _ctx _sk _to = Nothing
+
+    --
+    -- Key generation
+    --
+
+    unsoundPureGenKeyKES seed =
+      UnsoundPureSignKeySingleKES $! genKeyDSIGN seed
+
+    unsoundPureDeriveVerKeyKES (UnsoundPureSignKeySingleKES v) =
+      VerKeySingleKES $! deriveVerKeyDSIGN v
+
+    unsoundPureSignKeyKESToSoundSignKeyKES (UnsoundPureSignKeySingleKES sk) =
+      maybe (error "unsoundPureSignKeyKESToSoundSignKeyKES: deserialisation failure") (return . SignKeySingleKES)
+      =<< (rawDeserialiseSignKeyDSIGNM . rawSerialiseSignKeyDSIGN $ sk)
+
+    rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeySingleKES sk) =
+      rawSerialiseSignKeyDSIGN sk
+    rawDeserialiseUnsoundPureSignKeyKES b =
+      UnsoundPureSignKeySingleKES <$> rawDeserialiseSignKeyDSIGN b
+
 instance (KESAlgorithm (SingleKES d), UnsoundDSIGNMAlgorithm d)
          => UnsoundKESAlgorithm (SingleKES d) where
     rawSerialiseSignKeyKES (SignKeySingleKES sk) =
@@ -187,6 +219,22 @@ instance DSIGNMAlgorithm d => ToCBOR (SigKES (SingleKES d)) where
 
 instance DSIGNMAlgorithm d => FromCBOR (SigKES (SingleKES d)) where
   fromCBOR = decodeSigKES
+
+--
+-- UnsoundPureSignKey instances
+--
+
+deriving instance DSIGNAlgorithm d => Show (UnsoundPureSignKeyKES (SingleKES d))
+deriving instance Eq (SignKeyDSIGN d) => Eq   (UnsoundPureSignKeyKES (SingleKES d))
+
+instance (UnsoundDSIGNMAlgorithm d) => ToCBOR (UnsoundPureSignKeyKES (SingleKES d)) where
+  toCBOR = encodeUnsoundPureSignKeyKES
+  encodedSizeExpr _size _skProxy = encodedSignKeyKESSizeExpr (Proxy :: Proxy (SignKeyKES (SingleKES d)))
+
+instance (UnsoundDSIGNMAlgorithm d) => FromCBOR (UnsoundPureSignKeyKES (SingleKES d)) where
+  fromCBOR = decodeUnsoundPureSignKeyKES
+
+instance DSIGNAlgorithm d => NoThunks (UnsoundPureSignKeyKES  (SingleKES d))
 
 --
 -- Direct ser/deser

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -163,9 +163,8 @@ instance ( KESAlgorithm (SingleKES d)
     unsoundPureDeriveVerKeyKES (UnsoundPureSignKeySingleKES v) =
       VerKeySingleKES $! deriveVerKeyDSIGN v
 
-    unsoundPureSignKeyKESToSoundSignKeyKES (UnsoundPureSignKeySingleKES sk) =
-      maybe (error "unsoundPureSignKeyKESToSoundSignKeyKES: deserialisation failure") (return . SignKeySingleKES)
-      =<< (rawDeserialiseSignKeyDSIGNM . rawSerialiseSignKeyDSIGN $ sk)
+    unsoundPureSignKeyKESToSoundSignKeyKES =
+      unsoundPureSignKeyKESToSoundSignKeyKESViaSer
 
     rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeySingleKES sk) =
       rawSerialiseSignKeyDSIGN sk

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -50,7 +50,7 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash.Class
 import Cardano.Crypto.DSIGN.Class as DSIGN
 import Cardano.Crypto.KES.Class
-
+import Cardano.Crypto.DirectSerialise
 
 -- | A standard signature scheme is a forward-secure signature scheme with a
 -- single time period.
@@ -187,4 +187,19 @@ instance DSIGNMAlgorithm d => ToCBOR (SigKES (SingleKES d)) where
 
 instance DSIGNMAlgorithm d => FromCBOR (SigKES (SingleKES d)) where
   fromCBOR = decodeSigKES
-  {-# INLINE fromCBOR #-}
+
+--
+-- Direct ser/deser
+--
+
+instance (DirectSerialise (SignKeyDSIGNM d)) => DirectSerialise (SignKeyKES (SingleKES d)) where
+  directSerialise push (SignKeySingleKES sk) = directSerialise push sk
+
+instance (DirectDeserialise (SignKeyDSIGNM d)) => DirectDeserialise (SignKeyKES (SingleKES d)) where
+  directDeserialise pull = SignKeySingleKES <$!> directDeserialise pull
+
+instance (DirectSerialise (VerKeyDSIGN d)) => DirectSerialise (VerKeyKES (SingleKES d)) where
+  directSerialise push (VerKeySingleKES sk) = directSerialise push sk
+
+instance (DirectDeserialise (VerKeyDSIGN d)) => DirectDeserialise (VerKeyKES (SingleKES d)) where
+  directDeserialise pull = VerKeySingleKES <$!> directDeserialise pull

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -416,16 +416,14 @@ instance ( KESAlgorithm (SumKES h d)
     unsoundPureUpdateKES ctx (UnsoundPureSignKeySumKES sk r_1 vk_0 vk_1) t
       | t+1 <  _T = do
                         sk' <- unsoundPureUpdateKES ctx sk t
-                        let r_1' = r_1
-                        return $! UnsoundPureSignKeySumKES sk' r_1' vk_0 vk_1
+                        return $! UnsoundPureSignKeySumKES sk' r_1 vk_0 vk_1
       | t+1 == _T = do
                         let sk' = unsoundPureGenKeyKES r_1
                         let r_1' = mkSeedFromBytes (BS.replicate (fromIntegral (seedSizeKES (Proxy @d))) 0)
                         return $! UnsoundPureSignKeySumKES sk' r_1' vk_0 vk_1
       | otherwise = do
                         sk' <- unsoundPureUpdateKES ctx sk (t - _T)
-                        let r_1' = r_1
-                        return $! UnsoundPureSignKeySumKES sk' r_1' vk_0 vk_1
+                        return $! UnsoundPureSignKeySumKES sk' r_1 vk_0 vk_1
       where
         _T = totalPeriodsKES (Proxy :: Proxy d)
 
@@ -434,8 +432,7 @@ instance ( KESAlgorithm (SumKES h d)
     --
 
     unsoundPureGenKeyKES r =
-      let r0 = mkSeedFromBytes $ digest (Proxy @h) (BS.cons 1 $ getSeedBytes r)
-          r1 = mkSeedFromBytes $ digest (Proxy @h) (BS.cons 2 $ getSeedBytes r)
+      let (r0, r1) = expandSeed (Proxy @h) r
           sk_0 = unsoundPureGenKeyKES r0
           vk_0 = unsoundPureDeriveVerKeyKES sk_0
           sk_1 = unsoundPureGenKeyKES r1

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -64,6 +64,7 @@ import           Cardano.Crypto.Hash.Class
 import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.KES.Single (SingleKES)
 import           Cardano.Crypto.Util
+import           Cardano.Crypto.Seed
 import           Cardano.Crypto.Libsodium.MLockedSeed
 import           Cardano.Crypto.Libsodium
 import           Cardano.Crypto.Libsodium.Memory
@@ -388,6 +389,130 @@ instance (KESAlgorithm (SumKES h d), SodiumHashAlgorithm h, SizeHash h ~ SeedSiz
       => FromCBOR (SigKES (SumKES h d)) where
   fromCBOR = decodeSigKES
 
+--
+-- Unsound pure KES API
+--
+instance ( KESAlgorithm (SumKES h d)
+         , HashAlgorithm h
+         , UnsoundPureKESAlgorithm d
+         )
+         => UnsoundPureKESAlgorithm (SumKES h d) where
+    data UnsoundPureSignKeyKES (SumKES h d) =
+           UnsoundPureSignKeySumKES !(UnsoundPureSignKeyKES d)
+                         !Seed
+                         !(VerKeyKES d)
+                         !(VerKeyKES d)
+           deriving (Generic)
+
+    unsoundPureSignKES ctxt t a (UnsoundPureSignKeySumKES sk _r_1 vk_0 vk_1) =
+        SigSumKES sigma vk_0 vk_1
+      where
+        sigma
+          | t < _T    = unsoundPureSignKES ctxt  t       a sk
+          | otherwise = unsoundPureSignKES ctxt (t - _T) a sk
+
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    unsoundPureUpdateKES ctx (UnsoundPureSignKeySumKES sk r_1 vk_0 vk_1) t
+      | t+1 <  _T = do
+                        sk' <- unsoundPureUpdateKES ctx sk t
+                        let r_1' = r_1
+                        return $! UnsoundPureSignKeySumKES sk' r_1' vk_0 vk_1
+      | t+1 == _T = do
+                        let sk' = unsoundPureGenKeyKES r_1
+                        let r_1' = mkSeedFromBytes (BS.replicate (fromIntegral (seedSizeKES (Proxy @d))) 0)
+                        return $! UnsoundPureSignKeySumKES sk' r_1' vk_0 vk_1
+      | otherwise = do
+                        sk' <- unsoundPureUpdateKES ctx sk (t - _T)
+                        let r_1' = r_1
+                        return $! UnsoundPureSignKeySumKES sk' r_1' vk_0 vk_1
+      where
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    --
+    -- Key generation
+    --
+
+    unsoundPureGenKeyKES r =
+      let r0 = mkSeedFromBytes $ digest (Proxy @h) (BS.cons 1 $ getSeedBytes r)
+          r1 = mkSeedFromBytes $ digest (Proxy @h) (BS.cons 2 $ getSeedBytes r)
+          sk_0 = unsoundPureGenKeyKES r0
+          vk_0 = unsoundPureDeriveVerKeyKES sk_0
+          sk_1 = unsoundPureGenKeyKES r1
+          vk_1 = unsoundPureDeriveVerKeyKES sk_1
+      in UnsoundPureSignKeySumKES sk_0 r1 vk_0 vk_1
+
+    unsoundPureDeriveVerKeyKES (UnsoundPureSignKeySumKES _ _ vk_0 vk_1) =
+      VerKeySumKES (hashPairOfVKeys (vk_0, vk_1))
+
+    unsoundPureSignKeyKESToSoundSignKeyKES (UnsoundPureSignKeySumKES sk r_1 vk_0 vk_1) =
+      SignKeySumKES
+        <$> unsoundPureSignKeyKESToSoundSignKeyKES sk
+        <*> (fmap MLockedSeed . mlsbFromByteString . getSeedBytes $ r_1)
+        <*> pure vk_0
+        <*> pure vk_1
+
+    rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeySumKES sk r_1 vk_0 vk_1) =
+      let ssk = rawSerialiseUnsoundPureSignKeyKES sk
+          sr1 = getSeedBytes r_1
+      in mconcat
+          [ ssk
+          , sr1
+          , rawSerialiseVerKeyKES vk_0
+          , rawSerialiseVerKeyKES vk_1
+          ]
+
+    rawDeserialiseUnsoundPureSignKeyKES b = do
+        guard (BS.length b == fromIntegral size_total)
+        sk   <- rawDeserialiseUnsoundPureSignKeyKES b_sk
+        let r = mkSeedFromBytes b_r
+        vk_0 <- rawDeserialiseVerKeyKES  b_vk0
+        vk_1 <- rawDeserialiseVerKeyKES  b_vk1
+        return (UnsoundPureSignKeySumKES sk r vk_0 vk_1)
+      where
+        b_sk  = slice off_sk  size_sk b
+        b_r   = slice off_r   size_r  b
+        b_vk0 = slice off_vk0 size_vk b
+        b_vk1 = slice off_vk1 size_vk b
+
+        size_sk    = sizeSignKeyKES (Proxy :: Proxy d)
+        size_r     = seedSizeKES    (Proxy :: Proxy d)
+        size_vk    = sizeVerKeyKES  (Proxy :: Proxy d)
+        size_total = sizeSignKeyKES (Proxy :: Proxy (SumKES h d))
+
+        off_sk     = 0 :: Word
+        off_r      = size_sk
+        off_vk0    = off_r + size_r
+        off_vk1    = off_vk0 + size_vk
+
+
+--
+-- UnsoundPureSignKey instances
+--
+
+deriving instance (KESAlgorithm d, Show (UnsoundPureSignKeyKES d)) => Show (UnsoundPureSignKeyKES (SumKES h d))
+deriving instance (KESAlgorithm d, Eq (UnsoundPureSignKeyKES d)) => Eq   (UnsoundPureSignKeyKES (SumKES h d))
+
+instance ( SizeHash h ~ SeedSizeKES d
+         , UnsoundPureKESAlgorithm d
+         , SodiumHashAlgorithm h
+         , KnownNat (SizeVerKeyKES (SumKES h d))
+         , KnownNat (SizeSignKeyKES (SumKES h d))
+         , KnownNat (SizeSigKES (SumKES h d))
+         ) => ToCBOR (UnsoundPureSignKeyKES (SumKES h d)) where
+  toCBOR = encodeUnsoundPureSignKeyKES
+  encodedSizeExpr _size _skProxy = encodedSignKeyKESSizeExpr (Proxy :: Proxy (SignKeyKES (SumKES h d)))
+
+instance ( SizeHash h ~ SeedSizeKES d
+         , UnsoundPureKESAlgorithm d
+         , SodiumHashAlgorithm h
+         , KnownNat (SizeVerKeyKES (SumKES h d))
+         , KnownNat (SizeSignKeyKES (SumKES h d))
+         , KnownNat (SizeSigKES (SumKES h d))
+         ) => FromCBOR (UnsoundPureSignKeyKES (SumKES h d)) where
+  fromCBOR = decodeUnsoundPureSignKeyKES
+
+instance (NoThunks (UnsoundPureSignKeyKES d), KESAlgorithm d) => NoThunks (UnsoundPureSignKeyKES  (SumKES h d))
 
 --
 -- Direct ser/deser

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -65,10 +65,13 @@ import           Cardano.Crypto.KES.Single (SingleKES)
 import           Cardano.Crypto.Util
 import           Cardano.Crypto.Libsodium.MLockedSeed
 import           Cardano.Crypto.Libsodium
+import           Cardano.Crypto.Libsodium.Memory
+import           Cardano.Crypto.DirectSerialise
+
 import           Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import           Control.DeepSeq (NFData (..))
 import           GHC.TypeLits (KnownNat, type (+), type (*))
-
+import           Foreign.Ptr (castPtr)
 
 -- | A 2^0 period KES
 type Sum0KES d   = SingleKES d
@@ -383,4 +386,51 @@ instance (KESAlgorithm (SumKES h d), SodiumHashAlgorithm h, SizeHash h ~ SeedSiz
 instance (KESAlgorithm (SumKES h d), SodiumHashAlgorithm h, SizeHash h ~ SeedSizeKES d)
       => FromCBOR (SigKES (SumKES h d)) where
   fromCBOR = decodeSigKES
-  {-# INLINE fromCBOR #-}
+
+
+--
+-- Direct ser/deser
+--
+
+instance ( DirectSerialise (SignKeyKES d)
+         , DirectSerialise (VerKeyKES d)
+         , KESAlgorithm d
+         ) => DirectSerialise (SignKeyKES (SumKES h d)) where
+  directSerialise push (SignKeySumKES sk r vk0 vk1) = do
+    directSerialise push sk
+    mlockedSeedUseAsCPtr r $ \ptr ->
+      push (castPtr ptr) (fromIntegral $ seedSizeKES (Proxy :: Proxy d))
+    directSerialise push vk0
+    directSerialise push vk1
+
+instance ( DirectDeserialise (SignKeyKES d)
+         , DirectDeserialise (VerKeyKES d)
+         , KESAlgorithm d
+         ) => DirectDeserialise (SignKeyKES (SumKES h d)) where
+  directDeserialise pull = do
+    sk <- directDeserialise pull
+
+    r <- mlockedSeedNew
+    mlockedSeedUseAsCPtr r $ \ptr ->
+      pull (castPtr ptr) (fromIntegral $ seedSizeKES (Proxy :: Proxy d))
+
+    vk0 <- directDeserialise pull
+    vk1 <- directDeserialise pull
+
+    return $! SignKeySumKES sk r vk0 vk1
+
+
+instance DirectSerialise (VerKeyKES (SumKES h d)) where
+  directSerialise push (VerKeySumKES h) =
+    unpackByteStringCStringLen (hashToBytes h) $ \(ptr, len) ->
+      push (castPtr ptr) (fromIntegral len)
+
+instance (HashAlgorithm h)
+         => DirectDeserialise (VerKeyKES (SumKES h d)) where
+  directDeserialise pull = do
+    let len :: Num a => a
+        len = fromIntegral $ sizeHash (Proxy @h)
+    allocaBytes len $ \ptr -> do
+      pull ptr len
+      bs <- packByteStringCStringLen (ptr, len)
+      maybe (error "Invalid hash") return $! VerKeySumKES <$!> hashFromBytes bs

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
@@ -29,6 +29,8 @@ module Cardano.Crypto.Libsodium.C (
     c_crypto_sign_ed25519_detached,
     c_crypto_sign_ed25519_verify_detached,
     c_crypto_sign_ed25519_sk_to_pk,
+    -- * RNG
+    c_sodium_randombytes_buf,
     -- * Helpers
     c_sodium_compare,
     -- * Constants
@@ -182,3 +184,6 @@ foreign import capi unsafe "sodium.h crypto_sign_ed25519_sk_to_pk" c_crypto_sign
 --
 -- <https://libsodium.gitbook.io/doc/helpers#comparing-large-numbers>
 foreign import capi unsafe "sodium.h sodium_compare" c_sodium_compare :: Ptr a -> Ptr a -> CSize -> IO Int
+
+-- | @void randombytes_buf(void * const buf, const size_t size);@
+foreign import capi unsafe "sodium/randombytes.h randombytes_buf" c_sodium_randombytes_buf :: Ptr a -> CSize -> IO ()

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
@@ -25,6 +25,11 @@ module Cardano.Crypto.Libsodium.Memory (
   copyMem,
   allocaBytes,
 
+  -- * 'ForeignPtr' operations, generalized to 'MonadST'
+  ForeignPtr (..),
+  mallocForeignPtrBytes,
+  withForeignPtr,
+
   -- * ByteString memory access, generalized to 'MonadST'
   unpackByteStringCStringLen,
   packByteStringCStringLen,

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
@@ -26,6 +26,7 @@ module Cardano.Crypto.Libsodium.Memory (
   allocaBytes,
 
   -- * ByteString memory access, generalized to 'MonadST'
+  unpackByteStringCStringLen,
   packByteStringCStringLen,
 ) where
 

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
@@ -49,7 +49,7 @@ module Cardano.Crypto.Libsodium.Memory.Internal (
 import Control.DeepSeq (NFData (..), rwhnf)
 import Control.Exception (Exception, mask_)
 import Control.Monad (when, void)
-import Control.Monad.Class.MonadST
+import Control.Monad.Class.MonadST (MonadST, stToIO)
 import Control.Monad.Class.MonadThrow (MonadThrow (bracket))
 import Control.Monad.ST (RealWorld, ST)
 import Control.Monad.Primitive (touch)

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
@@ -29,6 +29,7 @@ module Cardano.Crypto.Libsodium.Memory.Internal (
   mlockedAllocForeignPtrBytesWith,
 
   -- * 'ForeignPtr' operations, generalized to 'MonadST'
+  ForeignPtr (..),
   mallocForeignPtrBytes,
   withForeignPtr,
 
@@ -58,7 +59,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Coerce (coerce)
 import Data.Typeable
-import Data.Word (Word8)
 import Debug.Trace (traceShowM)
 import Foreign.C.Error (errnoToIOError, getErrno)
 import Foreign.C.String (CStringLen)
@@ -66,22 +66,22 @@ import Foreign.C.Types (CSize (..))
 import qualified Foreign.Concurrent as Foreign
 import qualified Foreign.ForeignPtr as Foreign hiding (newForeignPtr)
 import qualified Foreign.ForeignPtr.Unsafe as Foreign
-import Foreign.ForeignPtr (ForeignPtr)
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.Marshal.Utils (fillBytes)
 import Foreign.Ptr (Ptr, nullPtr, castPtr)
-import Foreign.Storable (Storable (peek), sizeOf, alignment, pokeByteOff)
+import Foreign.Storable (Storable (peek), sizeOf, alignment)
 import GHC.IO.Exception (ioException)
 import GHC.TypeLits (KnownNat, natVal)
 import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 import System.IO.Unsafe (unsafePerformIO)
+import Data.Kind
 
 import Cardano.Crypto.Libsodium.C
 import Cardano.Foreign (c_memset, c_memcpy, SizedPtr (..))
 import Cardano.Memory.Pool (initPool, grabNextBlock, Pool)
 
 -- | Foreign pointer to securely allocated memory.
-newtype MLockedForeignPtr a = SFP { _unwrapMLockedForeignPtr :: ForeignPtr a }
+newtype MLockedForeignPtr a = SFP { _unwrapMLockedForeignPtr :: Foreign.ForeignPtr a }
   deriving NoThunks via OnlyCheckWhnfNamed "MLockedForeignPtr" (MLockedForeignPtr a)
 
 instance NFData (MLockedForeignPtr a) where
@@ -197,15 +197,20 @@ zeroMem ptr size = unsafeIOToMonadST . void $ c_memset (castPtr ptr) 0 size
 copyMem :: MonadST m => Ptr a -> Ptr a -> CSize -> m ()
 copyMem dst src size = unsafeIOToMonadST . void $ c_memcpy (castPtr dst) (castPtr src) size
 
-mallocForeignPtrBytes :: (MonadST m) => Int -> m (ForeignPtr a)
+-- | A 'ForeignPtr' type, generalized to 'MonadST'. The type is tagged with
+-- the correct Monad @m@ in order to ensure that foreign pointers created in
+-- one ST context can only be used within the same ST context.
+newtype ForeignPtr (m :: Type -> Type) a = ForeignPtr { unsafeRawForeignPtr :: Foreign.ForeignPtr a }
+
+mallocForeignPtrBytes :: (MonadST m) => Int -> m (ForeignPtr m a)
 mallocForeignPtrBytes size =
-  unsafeIOToMonadST (Foreign.mallocForeignPtrBytes size)
+  ForeignPtr <$> unsafeIOToMonadST (Foreign.mallocForeignPtrBytes size)
 
 -- | 'Foreign.withForeignPtr', generalized to 'MonadST'.
 -- Caveat: if the monadic action passed to 'withForeignPtr' does not terminate
 -- (e.g., 'forever'), the 'ForeignPtr' finalizer may run prematurely.
-withForeignPtr :: (MonadST m) => ForeignPtr a -> (Ptr a -> m b) -> m b
-withForeignPtr fptr f = do
+withForeignPtr :: (MonadST m) => ForeignPtr m a -> (Ptr a -> m b) -> m b
+withForeignPtr (ForeignPtr fptr) f = do
   result <- f $ Foreign.unsafeForeignPtrToPtr fptr
   stToIO $ touch fptr
   return result
@@ -220,10 +225,9 @@ allocaBytes size action = do
 unpackByteStringCStringLen :: (MonadThrow m, MonadST m) => ByteString -> (CStringLen -> m a) -> m a
 unpackByteStringCStringLen bs f = do
   let len = BS.length bs
-  allocaBytes (len + 1) $ \buf -> do
+  allocaBytes len $ \buf -> do
     unsafeIOToMonadST $ BS.unsafeUseAsCString bs $ \ptr -> do
       copyMem buf ptr (fromIntegral len)
-      pokeByteOff buf len (0 :: Word8)
     f (buf, len)
 
 packByteStringCStringLen :: MonadST m => CStringLen -> m ByteString

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -38,7 +38,7 @@ import Data.Kind (Type)
 import Control.DeepSeq (NFData)
 import Control.Monad.ST (runST)
 import Control.Monad.ST.Unsafe (unsafeIOToST)
-import Control.Monad.Class.MonadST
+import Control.Monad.Class.MonadST (MonadST, stToIO)
 import Control.Monad.Primitive  (primitive_, touch)
 import Data.Primitive.ByteArray
           ( ByteArray (..)

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -74,7 +74,7 @@ library
                       , contra-tracer ==0.1.0.1
                       , deepseq
                       , formatting
-                      , io-classes >= 1.1
+                      , io-classes >= 1.4.0
                       , mtl
                       , nothunks
                       , pretty-show

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -45,6 +45,7 @@ import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
 import Cardano.Crypto.DirectSerialise (DirectSerialise, directSerialise, DirectDeserialise)
 import Cardano.Crypto.Util (SignableRepresentation(..))
+import Cardano.Crypto.Seed (mkSeedFromBytes)
 import Cardano.Crypto.Libsodium
 import Cardano.Crypto.Libsodium.MLockedSeed
 import Cardano.Crypto.Libsodium.Memory
@@ -203,11 +204,14 @@ testKESAlgorithm
      , FromCBOR (VerKeyKES v)
      , EqST (SignKeyKES v)   -- only monadic EqST for signing keys
      , Show (SignKeyKES v) -- fake instance defined locally
+     , Eq (UnsoundPureSignKeyKES v)
+     , Show (UnsoundPureSignKeyKES v)
      , ToCBOR (SigKES v)
      , FromCBOR (SigKES v)
      , Signable v ~ SignableRepresentation
      , ContextKES v ~ ()
      , UnsoundKESAlgorithm v
+     , UnsoundPureKESAlgorithm v
      , DirectSerialise (SignKeyKES v)
      , DirectSerialise (VerKeyKES v)
      , DirectDeserialise (SignKeyKES v)
@@ -312,6 +316,9 @@ testKESAlgorithm lock n =
             ioPropertyWithSK @v lock $ \sk -> do
               sig :: SigKES v <- signKES () 0 msg sk
               return $ prop_cbor_with encodeSigKES decodeSigKES sig
+        , testProperty "UnsoundSignKeyKES" $ \seedPSB ->
+              let sk :: UnsoundPureSignKeyKES v = mkUnsoundPureSignKeyKES seedPSB
+              in prop_cbor_with encodeUnsoundPureSignKeyKES decodeUnsoundPureSignKeyKES sk
         ]
 
       , testGroup "To/FromCBOR class"
@@ -404,6 +411,12 @@ testKESAlgorithm lock n =
     --   [ testProperty "key overwritten after forget" $ prop_key_overwritten_after_forget (Proxy @v)
     --   ]
 
+    , testGroup "unsound pure"
+      [ testProperty "genKey" $ prop_unsoundPureGenKey @v Proxy
+      , testProperty "updateKES" $ prop_unsoundPureUpdateKES @v Proxy
+      , testProperty "deriveVerKey" $ prop_unsoundPureDeriveVerKey @v Proxy
+      , testProperty "sign" $ prop_unsoundPureSign @v Proxy
+      ]
     ]
 
 -- | Wrap an IO action that requires a 'SignKeyKES' into one that takes an
@@ -417,6 +430,12 @@ withSK seedPSB =
   bracket
     (withMLockedSeedFromPSB seedPSB genKeyKES)
     forgetSignKeyKES
+
+mkUnsoundPureSignKeyKES :: UnsoundPureKESAlgorithm v
+                        => PinnedSizedBytes (SeedSizeKES v) -> UnsoundPureSignKeyKES v
+mkUnsoundPureSignKeyKES psb =
+  let seed = mkSeedFromBytes . psbToByteString $ psb
+  in unsoundPureGenKeyKES seed
 
 -- | Wrap an IO action that requires a 'SignKeyKES' into a 'Property' that
 -- takes a non-mlocked seed (provided as a 'PinnedSizedBytes' of the
@@ -797,4 +816,74 @@ hasLongRunOfFF bs
   = let first16 = BS.take 16 bs
         remainder = BS.drop 16 bs
     in (BS.all (== 0xFF) first16) || hasLongRunOfFF remainder
+
+prop_unsoundPureGenKey :: forall v.
+                          ( UnsoundPureKESAlgorithm v
+                          , EqST (SignKeyKES v)
+                          )
+                       => Proxy v -> PinnedSizedBytes (SeedSizeKES v) -> Property
+prop_unsoundPureGenKey _ seedPSB = ioProperty $ do
+  let seed = mkSeedFromBytes $ psbToByteString seedPSB
+  let skPure = unsoundPureGenKeyKES @v seed
+  withSK seedPSB $ \sk -> do
+    bracket
+      (unsoundPureSignKeyKESToSoundSignKeyKES skPure)
+      forgetSignKeyKES
+      (equalsM sk)
+
+prop_unsoundPureDeriveVerKey :: forall v.
+                          ( UnsoundPureKESAlgorithm v
+                          )
+                       => Proxy v -> PinnedSizedBytes (SeedSizeKES v) -> Property
+prop_unsoundPureDeriveVerKey _ seedPSB = ioProperty $ do
+  let seed = mkSeedFromBytes $ psbToByteString seedPSB
+  let skPure = unsoundPureGenKeyKES @v seed
+      vkPure = unsoundPureDeriveVerKeyKES @v skPure
+  vk <- withSK seedPSB deriveVerKeyKES
+  return $ vkPure === vk
+
+prop_unsoundPureUpdateKES :: forall v.
+                             ( UnsoundPureKESAlgorithm v
+                             , ContextKES v ~ ()
+                             , EqST (SignKeyKES v)
+                             )
+                       => Proxy v -> PinnedSizedBytes (SeedSizeKES v) -> Property
+prop_unsoundPureUpdateKES _ seedPSB = ioProperty $ do
+  let seed = mkSeedFromBytes $ psbToByteString seedPSB
+  let skPure = unsoundPureGenKeyKES @v seed
+      skPure'Maybe = unsoundPureUpdateKES () skPure 0
+  withSK seedPSB $ \sk -> do
+    bracket
+      (updateKES () sk 0)
+      (maybe (return ()) forgetSignKeyKES) $ \sk'Maybe -> do
+        case skPure'Maybe of
+          Nothing ->
+            case sk'Maybe of
+              Nothing -> return $ property True
+              Just _ -> return $ counterexample "pure does not update, but should" $ property False
+          Just skPure' ->
+            bracket
+              (unsoundPureSignKeyKESToSoundSignKeyKES skPure')
+              forgetSignKeyKES $ \sk'' ->
+                case sk'Maybe of
+                  Nothing ->
+                    return (counterexample "pure updates, but shouldn't" $ property False)
+                  Just sk' ->
+                    property <$> equalsM sk' sk''
+
+prop_unsoundPureSign :: forall v.
+                          ( UnsoundPureKESAlgorithm v
+                          , ContextKES v ~ ()
+                          , Signable v Message
+                          )
+                       => Proxy v
+                       -> PinnedSizedBytes (SeedSizeKES v)
+                       -> Message
+                       -> Property
+prop_unsoundPureSign _ seedPSB msg = ioProperty $ do
+  let seed = mkSeedFromBytes $ psbToByteString seedPSB
+  let skPure = unsoundPureGenKeyKES @v seed
+      sigPure = unsoundPureSignKES () 0 msg skPure
+  sig <- withSK seedPSB $ signKES () 0 msg
+  return $ sigPure === sig
 

--- a/cardano-crypto-tests/src/Test/Crypto/Util.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Util.hs
@@ -59,6 +59,10 @@ module Test.Crypto.Util
   , noExceptionsThrown
   , doesNotThrow
 
+  -- * Direct ser/deser helpers
+  , directSerialiseToBS
+  , directDeserialiseFromBS
+
     -- * Error handling
   , eitherShowError
 
@@ -95,11 +99,18 @@ import Codec.CBOR.Write (
   )
 import Cardano.Crypto.Seed (Seed, mkSeedFromBytes)
 import Cardano.Crypto.Util (SignableRepresentation(..))
+import Cardano.Crypto.DirectSerialise
 import Crypto.Random
   ( ChaChaDRG
   , MonadPseudoRandom
   , drgNewTest
   , withDRG
+  )
+import Cardano.Crypto.Libsodium.Memory
+  ( unpackByteStringCStringLen
+  , packByteStringCStringLen
+  , allocaBytes
+  , copyMem
   )
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -130,7 +141,19 @@ import qualified Test.QuickCheck.Gen as Gen
 import Control.Monad (guard, when)
 import GHC.TypeLits (Nat, KnownNat, natVal)
 import Formatting.Buildable (Buildable (..), build)
-import Control.Concurrent.Class.MonadMVar (MVar, withMVar, newMVar)
+import Foreign.Ptr (Ptr, plusPtr)
+import Foreign.C.Types (CChar, CSize)
+import Control.Monad.Class.MonadST (MonadST)
+import Control.Monad.Class.MonadThrow (MonadThrow)
+import Control.Concurrent.Class.MonadMVar
+  ( MVar
+  , withMVar
+  , newMVar
+  , putMVar
+  , takeMVar
+  , newMVar
+  , MonadMVar
+  )
 import GHC.Stack (HasCallStack)
 
 --------------------------------------------------------------------------------
@@ -375,3 +398,44 @@ mkLock = Lock <$> newMVar ()
 eitherShowError :: (HasCallStack, Show e) => Either e a -> IO a
 eitherShowError (Left e) = error (show e)
 eitherShowError (Right a) = return a
+
+--------------------------------------------------------------------------------
+-- Helpers for direct ser/deser
+--------------------------------------------------------------------------------
+
+directSerialiseToBS :: forall m a.
+                       DirectSerialise a
+                    => MonadST m
+                    => MonadThrow m
+                    => MonadMVar m
+                    => Int -> a -> m ByteString
+directSerialiseToBS dstsize val = do
+  allocaBytes dstsize $ \dst -> do
+    posVar <- newMVar 0
+    let pusher :: Ptr CChar -> CSize -> m ()
+        pusher src srcsize = do
+          pos <- takeMVar posVar
+          let pos' = pos + fromIntegral srcsize
+          when (pos' > dstsize) (error "Buffer overrun")
+          copyMem (plusPtr dst pos) src (fromIntegral srcsize)
+          putMVar posVar pos'
+    directSerialise pusher val
+    packByteStringCStringLen (dst, fromIntegral dstsize)
+
+directDeserialiseFromBS :: forall m a.
+                           DirectDeserialise a
+                           => MonadST m
+                           => MonadThrow m
+                           => MonadMVar m
+                           => ByteString -> m a
+directDeserialiseFromBS bs = do
+  unpackByteStringCStringLen bs $ \(src, srcsize) -> do
+    posVar <- newMVar 0
+    let puller :: Ptr CChar -> CSize -> m ()
+        puller dst dstsize = do
+          pos <- takeMVar posVar
+          let pos' = pos + fromIntegral dstsize
+          when (pos' > srcsize) (error "Buffer overrun")
+          copyMem dst (plusPtr src pos) (fromIntegral dstsize)
+          putMVar posVar pos'
+    directDeserialise puller


### PR DESCRIPTION
# Description

This introduces two changes that are needed for introducing mlocked KES into ouroboros-consensus and implementing a KES agent:

- The `DirectSerialise` API, an abstraction that allows us to send key data over a socket connection directly from mlocked memory, without using any intermediate variables on the GHC heap that might leak secrets to disk
- Reinstating the non-mlocked KES API as `UnsoundPureKES`; this is necessary for a minimally disruptive migration path in ouroboros-consensus. We will use this API to keep the existing code, loading KES keys from disk, available, while adding KES agent connectivity (which will use mlocked memory throughout) as an alternative. Until all non-mlocked KES usage has been phased out, we will need to keep the `UnsoundPureKES` API around.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
