### PR TITLE
Test cabal-cache-native

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -40,9 +40,6 @@ jobs:
       run:
         shell: bash
 
-    strategy:
-      fail-fast: false
-
     steps:
     - uses: actions/checkout@v4
 
@@ -111,42 +108,17 @@ jobs:
     - name: Build dry run
       run: cabal build all --enable-tests --dry-run --minimize-conflict-set
 
-    # From the install plan we generate a dependency list.
-    - name: Record dependencies
-      id: record-deps
-      run: |
-        # The tests call out to msys2 commands. We generally do not want to mix toolchains, so
-        # we are very deliberate about only adding msys64 to the path where absolutely necessary.
-        ${{ (runner.os == 'Windows' && '$env:PATH=("C:\msys64\mingw64\bin;{0}" -f $env:PATH)') || '' }}
-        cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
-
-    # From the dependency list we restore the cached dependencies.
-    # We use the hash of `dependencies.txt` as part of the cache key because that will be stable
-    # until the `index-state` values in the `cabal.project` file changes.
-    - name: Restore cached dependencies
-      uses: actions/cache/restore@v4
-      id: cache
+    - uses: actions/upload-artifact@v4
+      id: upload-artifact
       with:
-        path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
-          dist-newstyle
-        key: cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+        name: plan-${{ matrix.ghc }}-${{ matrix.os }}.json
+        path: dist-newstyle/cache/plan.json
 
-    # Now we install the dependencies. If the cache was found and restored in the previous step,
-    # this should be a no-op, but if the cache key was not found we need to build stuff so we can
-    # cache it for the next step.
-    - name: Install dependencies
-      run: cabal build all --enable-tests --only-dependencies -j --ghc-option=-j4
+    - run: echo "${{ steps.upload-artifact.artifact-url }}" >> $GITHUB_STEP_SUMMARY
 
-    # Always store the cabal cache.
-    # This may fail (benign failure) if the cache key is already populated.
-    - name: Cache Cabal store
-      uses: actions/cache/save@v4
+    - uses: andreabedini/cabal-cache-native@main
       with:
-        path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
-          dist-newstyle
-        key: cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+        store-path: ${{ steps.setup-haskell.outputs.cabal-store }}
 
     # Now we build.
     - name: Build [testing]


### PR DESCRIPTION
# Description

This PR changes the Haskell CI workflow to use https://github.com/andreabedini/cabal-cache-native for granular caching of haskell dependencies built by cabal.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Self-reviewed the diff
