### PR TITLE
expose Scalar, Field and the Point ptr

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -23,6 +23,7 @@ solidified. Ask @lehins if backport is needed.
 * Re-introduction of non-mlocked KES implementations to support a smoother
   migration path:
   [#504](https://github.com/IntersectMBO/cardano-base/pull/504)
+* Exposing constructors of the BLS12-381 internals: [#509](https://github.com/IntersectMBO/cardano-base/pull/509)
 
 ## 2.1.0.2
 

--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -42,7 +42,7 @@ module Cardano.Crypto.EllipticCurve.BLS12_381.Internal
   , BLSTError (..)
   , Point (..)
   , Point1
-  , Point2 
+  , Point2
   , PT
   , Scalar (..)
   , Fr (..)

--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -11,7 +11,7 @@ module Cardano.Crypto.EllipticCurve.BLS12_381.Internal
 (
   -- * Unsafe Types
     ScalarPtr
-  , PointPtr
+  , PointPtr (..)
   , AffinePtr
 
   , Point1Ptr
@@ -40,11 +40,12 @@ module Cardano.Crypto.EllipticCurve.BLS12_381.Internal
   , Affine1
   , Affine2
   , BLSTError (..)
-  , Point
+  , Point (..)
   , Point1
-  , Point2
+  , Point2 
   , PT
-  , Scalar
+  , Scalar (..)
+  , Fr (..)
 
   , unsafePointFromPointPtr
 


### PR DESCRIPTION
# Description

This PR exposes the constructors of the types: `PointPtr`, `Point` and `Scalar`. Additionally, it exports the type `Fr` type and its constructor. 

The goal here is so that we can use them in [this](https://github.com/cardano-scaling/haskell-accumulator/blob/86d7bb20ab529878212191b766774e972297d4a9/haskell-accumulator/lib/Bindings/Internal.hs#L9) package.

This change will cause some trouble for the plutus repository (I had to fork it when also depending on cardano-base with these changes).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
