### PR TITLE
Use cabal-gild to format cabal files

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -215,3 +215,21 @@ jobs:
 
     - name: Run fourmolu
       run: ./scripts/fourmolize.sh
+
+  cabal-format:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tfausak/cabal-gild-setup-action@v2
+        with:
+          version: 1.5.0.1
+      - name: Format all cabal files
+        run: ./scripts/cabal-format.sh check

--- a/base-deriving-via/base-deriving-via.cabal
+++ b/base-deriving-via/base-deriving-via.cabal
@@ -1,22 +1,21 @@
-cabal-version:       >=1.10
-
-name:                base-deriving-via
-version:             0.1.0.2
-synopsis:            A general hook newtype for use with deriving via
-license:             Apache-2.0
+cabal-version: >=1.10
+name: base-deriving-via
+version: 0.1.0.2
+synopsis: A general hook newtype for use with deriving via
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           IOHK
-build-type:          Simple
-extra-source-files:  CHANGELOG.md
+
+author: IOHK
+maintainer: operations@iohk.io
+copyright: IOHK
+build-type: Simple
+extra-source-files: CHANGELOG.md
 
 library
-  default-language:     Haskell2010
-  hs-source-dirs:       src
-
+  default-language: Haskell2010
+  hs-source-dirs: src
   ghc-options:
     -Wall
     -Wcompat
@@ -28,8 +27,8 @@ library
     -Wmissing-export-lists
 
   exposed-modules:
-                        Data.DerivingVia
-                        Data.DerivingVia.GHC.Generics.Monoid
-                        Data.DerivingVia.GHC.Generics.Semigroup
+    Data.DerivingVia
+    Data.DerivingVia.GHC.Generics.Monoid
+    Data.DerivingVia.GHC.Generics.Semigroup
 
-  build-depends:        base
+  build-depends: base

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,6 @@ repository cardano-haskell-packages
 index-state: 2024-12-10T00:00:00Z
 -- The CHaP index-state
 index-state: cardano-haskell-packages 2024-10-10T04:22:19Z
-
 packages:
   base-deriving-via
   cardano-binary
@@ -30,7 +29,6 @@ packages:
 
 -- Ensures colourized output from test runners
 test-show-details: direct
-
 tests: true
 benchmarks: true
 

--- a/cardano-binary/cardano-binary.cabal
+++ b/cardano-binary/cardano-binary.cabal
@@ -1,101 +1,106 @@
 cabal-version: 3.0
-
-name:                cardano-binary
-version:             1.7.1.0
-synopsis:            Binary serialization for Cardano
-description:         This package includes the binary serialization format for Cardano
-license:             Apache-2.0
+name: cardano-binary
+version: 1.7.1.0
+synopsis: Binary serialization for Cardano
+description: This package includes the binary serialization format for Cardano
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           2019-2021 IOHK
-category:            Currency
-build-type:          Simple
-extra-source-files:  README.md
-                     CHANGELOG.md
 
-common base                         { build-depends: base >= 4.14 && < 5 }
+author: IOHK
+maintainer: operations@iohk.io
+copyright: 2019-2021 IOHK
+category: Currency
+build-type: Simple
+extra-source-files:
+  CHANGELOG.md
+  README.md
+
+common base
+  build-depends: base >=4.14 && <5
 
 common project-config
-  default-language:     Haskell2010
-
-  ghc-options:          -Wall
-                        -Wcompat
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wpartial-fields
-                        -Wredundant-constraints
-                        -Wunused-packages
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
+    -Wunused-packages
 
 library
-  import:               base, project-config
-  hs-source-dirs:       src
-  exposed-modules:      Cardano.Binary
-  other-modules:        Cardano.Binary.ToCBOR
-                        Cardano.Binary.FromCBOR
+  import: base, project-config
+  hs-source-dirs: src
+  exposed-modules: Cardano.Binary
+  other-modules:
+    Cardano.Binary.Deserialize
+    Cardano.Binary.FromCBOR
+    Cardano.Binary.Serialize
+    Cardano.Binary.ToCBOR
 
-                        Cardano.Binary.Serialize
-                        Cardano.Binary.Deserialize
-
-  build-depends:        base
-                      , bytestring
-                      , cborg              >= 0.2.9 && < 0.3
-                      , containers
-                      , data-fix
-                      , formatting
-                      , primitive
-                      , recursion-schemes  >= 5.1   && < 5.3
-                      , safe-exceptions
-                      , tagged
-                      , text
-                      , time
-                      , vector
+  build-depends:
+    base,
+    bytestring,
+    cborg >=0.2.9 && <0.3,
+    containers,
+    data-fix,
+    formatting,
+    primitive,
+    recursion-schemes >=5.1 && <5.3,
+    safe-exceptions,
+    tagged,
+    text,
+    time,
+    vector,
 
 library testlib
-  import:               base, project-config
-  visibility:           public
-  hs-source-dirs:       testlib
-  exposed-modules:      Test.Cardano.Binary.TreeDiff
-  build-depends:        base
-                      , bytestring
-                      , base16-bytestring
-                      , cardano-binary
-                      , cborg
-                      , formatting
-                      , tree-diff
-
+  import: base, project-config
+  visibility: public
+  hs-source-dirs: testlib
+  exposed-modules: Test.Cardano.Binary.TreeDiff
+  build-depends:
+    base,
+    base16-bytestring,
+    bytestring,
+    cardano-binary,
+    cborg,
+    formatting,
+    tree-diff,
 
 test-suite test
-  import:               base, project-config
-  hs-source-dirs:       test
-  main-is:              test.hs
-  type:                 exitcode-stdio-1.0
+  import: base, project-config
+  hs-source-dirs: test
+  main-is: test.hs
+  type: exitcode-stdio-1.0
+  other-modules:
+    Test.Cardano.Binary.Failure
+    Test.Cardano.Binary.Helpers
+    Test.Cardano.Binary.Helpers.GoldenRoundTrip
+    Test.Cardano.Binary.RoundTrip
+    Test.Cardano.Binary.Serialization
+    Test.Cardano.Binary.SizeBounds
 
-  other-modules:        Test.Cardano.Binary.SizeBounds
-                        Test.Cardano.Binary.Helpers
-                        Test.Cardano.Binary.Helpers.GoldenRoundTrip
-                        Test.Cardano.Binary.RoundTrip
-                        Test.Cardano.Binary.Serialization
-                        Test.Cardano.Binary.Failure
+  build-depends:
+    QuickCheck,
+    base,
+    bytestring,
+    cardano-binary,
+    cardano-prelude-test,
+    cborg,
+    containers,
+    formatting,
+    hedgehog,
+    hspec,
+    pretty-show,
+    quickcheck-instances,
+    tagged,
+    text,
+    time,
+    vector,
 
-  build-depends:        base
-                      , bytestring
-                      , cardano-binary
-                      , cardano-prelude-test
-                      , cborg
-                      , containers
-                      , formatting
-                      , hedgehog
-                      , hspec
-                      , pretty-show
-                      , QuickCheck
-                      , quickcheck-instances
-                      , tagged
-                      , text
-                      , time
-                      , vector
-
-  ghc-options:          -threaded
-                        -rtsopts
+  ghc-options:
+    -threaded
+    -rtsopts

--- a/cardano-binary/test/cardano-binary-test.cabal
+++ b/cardano-binary/test/cardano-binary-test.cabal
@@ -1,50 +1,52 @@
 cabal-version: 2.2
+name: cardano-binary-test
+version: 1.4.0.2
+synopsis: Test helpers from cardano-binary exposed to other packages
+description: Test helpers from cardano-binary exposed to other packages
+license: MIT
+license-file: LICENSE
+author: IOHK
+maintainer: operations@iohk.io
+copyright: 2019-2021 IOHK
+category: Currency
+build-type: Simple
+extra-source-files: CHANGELOG.md
 
-name:                cardano-binary-test
-version:             1.4.0.2
-synopsis:            Test helpers from cardano-binary exposed to other packages
-description:         Test helpers from cardano-binary exposed to other packages
-license:             MIT
-license-file:        LICENSE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           2019-2021 IOHK
-category:            Currency
-build-type:          Simple
-extra-source-files:  CHANGELOG.md
-
-common base                         { build-depends: base >= 4.14 && < 5 }
+common base
+  build-depends: base >=4.14 && <5
 
 common project-config
-  default-language:     Haskell2010
-
-  ghc-options:          -Wall
-                        -Wcompat
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wpartial-fields
-                        -Wredundant-constraints
-                        -Wunused-packages
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
+    -Wunused-packages
 
 library
-  import:               base, project-config
-  exposed-modules:      Test.Cardano.Binary.Helpers
-                        Test.Cardano.Binary.Helpers.GoldenRoundTrip
-                        Test.Cardano.Binary.Serialization
-                        Test.Cardano.Binary.Failure
+  import: base, project-config
+  exposed-modules:
+    Test.Cardano.Binary.Failure
+    Test.Cardano.Binary.Helpers
+    Test.Cardano.Binary.Helpers.GoldenRoundTrip
+    Test.Cardano.Binary.Serialization
 
-  build-depends:        base
-                      , bytestring
-                      , cardano-binary >= 1.6
-                      , cardano-prelude-test
-                      , cborg
-                      , containers
-                      , formatting
-                      , hedgehog
-                      , hspec
-                      , pretty-show
-                      , QuickCheck
-                      , quickcheck-instances
-                      , text
-                      , time
-                      , vector
+  build-depends:
+    QuickCheck,
+    base,
+    bytestring,
+    cardano-binary >=1.6,
+    cardano-prelude-test,
+    cborg,
+    containers,
+    formatting,
+    hedgehog,
+    hspec,
+    pretty-show,
+    quickcheck-instances,
+    text,
+    time,
+    vector,

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,51 +1,59 @@
-cabal-version:      2.2
-name:               cardano-crypto-class
-version:            2.2.0.0
+cabal-version: 2.2
+name: cardano-crypto-class
+version: 2.2.0.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 
 description:
   Type classes abstracting over cryptography primitives for Cardano
 
-license:            Apache-2.0
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
 
-author:             IOHK
-maintainer:         operations@iohk.io
-copyright:          2019-2021 IOHK
-category:           Currency
-build-type:         Simple
-extra-source-files: README.md
-                    CHANGELOG.md
+author: IOHK
+maintainer: operations@iohk.io
+copyright: 2019-2021 IOHK
+category: Currency
+build-type: Simple
+extra-source-files:
+  CHANGELOG.md
+  README.md
 
 flag secp256k1-support
-    description: Enable support for functions from libsecp256k1. Requires
-                 a recent libsecp256k1 with support for Schnorr signatures.
-    default: True
-    manual: True
+  description:
+    Enable support for functions from libsecp256k1. Requires
+    a recent libsecp256k1 with support for Schnorr signatures.
 
-common base                         { build-depends: base >= 4.14 && < 5 }
+  default: True
+  manual: True
+
+common base
+  build-depends: base >=4.14 && <5
 
 common project-config
   default-language: Haskell2010
   ghc-options:
-    -Wall -Wcompat -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
     -Wunused-packages
 
 library
-  import:            base, project-config
-  hs-source-dirs:    src
+  import: base, project-config
+  hs-source-dirs: src
   exposed-modules:
-    Cardano.Crypto.DirectSerialise
     Cardano.Crypto.DSIGN
     Cardano.Crypto.DSIGN.Class
     Cardano.Crypto.DSIGN.Ed25519
     Cardano.Crypto.DSIGN.Ed448
     Cardano.Crypto.DSIGN.Mock
     Cardano.Crypto.DSIGN.NeverUsed
+    Cardano.Crypto.DirectSerialise
     Cardano.Crypto.EllipticCurve.BLS12_381
     Cardano.Crypto.EllipticCurve.BLS12_381.Internal
     Cardano.Crypto.Hash
@@ -73,11 +81,11 @@ library
     Cardano.Crypto.Libsodium.Hash
     Cardano.Crypto.Libsodium.Hash.Class
     Cardano.Crypto.Libsodium.Init
-    Cardano.Crypto.Libsodium.Memory
-    Cardano.Crypto.Libsodium.Memory.Internal
     Cardano.Crypto.Libsodium.MLockedBytes
     Cardano.Crypto.Libsodium.MLockedBytes.Internal
     Cardano.Crypto.Libsodium.MLockedSeed
+    Cardano.Crypto.Libsodium.Memory
+    Cardano.Crypto.Libsodium.Memory.Internal
     Cardano.Crypto.Libsodium.UnsafeC
     Cardano.Crypto.PinnedSizedBytes
     Cardano.Crypto.Seed
@@ -93,58 +101,61 @@ library
     Cardano.Crypto.PackedBytes
 
   build-depends:
-    , aeson
-    , base
-    , base16-bytestring  >=1
-    , bytestring
-    , cardano-binary >= 1.6
-    , cardano-strict-containers
-    , crypton
-    , deepseq
-    , heapwords
-    , io-classes >= 1.4.1
-    , memory
-    , mempack
-    , memory-pool
-    , mtl
-    , nothunks
-    , primitive >= 0.8
-    , serialise
-    , template-haskell
-    , th-compat
-    , text
-    , transformers
-    , vector
+    aeson,
+    base,
+    base16-bytestring >=1,
+    bytestring,
+    cardano-binary >=1.6,
+    cardano-strict-containers,
+    crypton,
+    deepseq,
+    heapwords,
+    io-classes >=1.4.1,
+    memory,
+    memory-pool,
+    mempack,
+    mtl,
+    nothunks,
+    primitive >=0.8,
+    serialise,
+    template-haskell,
+    text,
+    th-compat,
+    transformers,
+    vector,
 
-  if impl(ghc < 9.0.0)
+  if impl(ghc <9.0.0)
     build-depends:
       integer-gmp
+  pkgconfig-depends:
+    libblst,
+    libsodium,
 
-  pkgconfig-depends: libsodium, libblst
   c-sources: cbits/blst_util.c
 
   if flag(secp256k1-support)
     exposed-modules:
       Cardano.Crypto.DSIGN.EcdsaSecp256k1
       Cardano.Crypto.DSIGN.SchnorrSecp256k1
-      Cardano.Crypto.SECP256K1.Constants
       Cardano.Crypto.SECP256K1.C
+      Cardano.Crypto.SECP256K1.Constants
+
     pkgconfig-depends: libsecp256k1
     cpp-options: -DSECP256K1_ENABLED
 
 test-suite test-memory-example
-  import:         base, project-config
+  import: base, project-config
   -- Temporarily removing this as it is breaking the CI, and
   -- we don't see the benefit. Will circle back to this to decide
   -- whether to modify or completely remove.
-  buildable:      False
-  type:           exitcode-stdio-1.0
+  buildable: False
+  type: exitcode-stdio-1.0
   hs-source-dirs: memory-example
-  main-is:        Main.hs
+  main-is: Main.hs
   build-depends:
-    , base
-    , bytestring
-    , cardano-crypto-class
+    base,
+    bytestring,
+    cardano-crypto-class,
 
   if (os(linux) || os(osx))
     build-depends: unix

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -1,87 +1,89 @@
 cabal-version: 2.2
-
-name:                cardano-crypto-praos
-version:             2.2.0.0
-synopsis:            Crypto primitives from libsodium
-description:         VRF (and KES, tba) primitives from libsodium.
-license:             Apache-2.0
+name: cardano-crypto-praos
+version: 2.2.0.0
+synopsis: Crypto primitives from libsodium
+description: VRF (and KES, tba) primitives from libsodium.
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           2019-2021 IOHK
-category:            Currency
-build-type:          Simple
-extra-source-files:  README.md
-                     CHANGELOG.md
 
-extra-source-files:    cbits/crypto_vrf.h
+author: IOHK
+maintainer: operations@iohk.io
+copyright: 2019-2021 IOHK
+category: Currency
+build-type: Simple
+extra-source-files:
+  CHANGELOG.md
+  README.md
 
-                       cbits/vrf03/crypto_vrf_ietfdraft03.h
-
-                       cbits/vrf13_batchcompat/crypto_vrf_ietfdraft13.h
-
-                       cbits/private/common.h
-                       cbits/private/ed25519_ref10.h
-                       cbits/private/core_h2c.h
-                       cbits/private/ed25519_ref10_fe_25_5.h
-                       cbits/private/ed25519_ref10_fe_51.h
-
-                       cbits/private/fe_25_5/constants.h
-                       cbits/private/fe_25_5/base.h
-                       cbits/private/fe_25_5/base2.h
-                       cbits/private/fe_25_5/fe.h
-                       cbits/private/fe_51/constants.h
-                       cbits/private/fe_51/base.h
-                       cbits/private/fe_51/base2.h
-                       cbits/private/fe_51/fe.h
+extra-source-files:
+  cbits/crypto_vrf.h
+  cbits/private/common.h
+  cbits/private/core_h2c.h
+  cbits/private/ed25519_ref10.h
+  cbits/private/ed25519_ref10_fe_25_5.h
+  cbits/private/ed25519_ref10_fe_51.h
+  cbits/private/fe_25_5/base.h
+  cbits/private/fe_25_5/base2.h
+  cbits/private/fe_25_5/constants.h
+  cbits/private/fe_25_5/fe.h
+  cbits/private/fe_51/base.h
+  cbits/private/fe_51/base2.h
+  cbits/private/fe_51/constants.h
+  cbits/private/fe_51/fe.h
+  cbits/vrf03/crypto_vrf_ietfdraft03.h
+  cbits/vrf13_batchcompat/crypto_vrf_ietfdraft13.h
 
 flag external-libsodium-vrf
-    description: Rely on a special libsodium fork containing the VRF code.
-                 Otherwise expect a normal unaltered system libsodium, and
-                 bundle the VRF code.
-    default: True
-    manual: True
+  description:
+    Rely on a special libsodium fork containing the VRF code.
+    Otherwise expect a normal unaltered system libsodium, and
+    bundle the VRF code.
 
-common base                         { build-depends: base >= 4.14 && < 5 }
+  default: True
+  manual: True
+
+common base
+  build-depends: base >=4.14 && <5
 
 common project-config
-  default-language:     Haskell2010
-
-  ghc-options:          -Wall
-                        -Wcompat
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wpartial-fields
-                        -Wredundant-constraints
-                        -Wunused-packages
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
+    -Wunused-packages
 
 library
-  import:               base, project-config
-  hs-source-dirs:       src
-  exposed-modules:      Cardano.Crypto.VRF.Praos
-                 ,      Cardano.Crypto.VRF.PraosBatchCompat
-                 ,      Cardano.Crypto.RandomBytes
+  import: base, project-config
+  hs-source-dirs: src
+  exposed-modules:
+    Cardano.Crypto.RandomBytes
+    Cardano.Crypto.VRF.Praos
+    Cardano.Crypto.VRF.PraosBatchCompat
 
-  build-depends:        base
-                      , bytestring
-                      , cardano-binary
-                      , cardano-crypto-class >= 2.1.1
-                      , deepseq
-                      , nothunks
+  build-depends:
+    base,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class >=2.1.1,
+    deepseq,
+    nothunks,
 
   pkgconfig-depends: libsodium
 
   if !flag(external-libsodium-vrf)
-    c-sources:          cbits/crypto_vrf.c
-                        cbits/vrf03/prove.c
-                        cbits/vrf03/verify.c
-                        cbits/vrf03/vrf.c
-
-                        cbits/vrf13_batchcompat/verify.c
-                        cbits/vrf13_batchcompat/prove.c
-                        cbits/vrf13_batchcompat/vrf.c
-
-                        cbits/private/core_h2c.c
-                        cbits/private/ed25519_ref10.c
+    c-sources:
+      cbits/crypto_vrf.c
+      cbits/private/core_h2c.c
+      cbits/private/ed25519_ref10.c
+      cbits/vrf03/prove.c
+      cbits/vrf03/verify.c
+      cbits/vrf03/vrf.c
+      cbits/vrf13_batchcompat/prove.c
+      cbits/vrf13_batchcompat/verify.c
+      cbits/vrf13_batchcompat/vrf.c

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -1,125 +1,135 @@
 cabal-version: 2.2
-
-name:                cardano-crypto-tests
-version:             2.2.0.0
-synopsis:            Tests for cardano-crypto-class and -praos
-description:         Tests for cardano-crypto-class and -praos
-license:             Apache-2.0
+name: cardano-crypto-tests
+version: 2.2.0.0
+synopsis: Tests for cardano-crypto-class and -praos
+description: Tests for cardano-crypto-class and -praos
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           2020-2021 IOHK
-category:            Currency
-build-type:          Simple
-extra-source-files:  README.md
-                     CHANGELOG.md
-data-files: bls12-381-test-vectors/test_vectors/bls_sig_aug_test_vectors
-            bls12-381-test-vectors/test_vectors/ec_operations_test_vectors
-            bls12-381-test-vectors/test_vectors/h2c_large_dst
-            bls12-381-test-vectors/test_vectors/pairing_test_vectors
-            bls12-381-test-vectors/test_vectors/serde_test_vectors
+
+author: IOHK
+maintainer: operations@iohk.io
+copyright: 2020-2021 IOHK
+category: Currency
+build-type: Simple
+extra-source-files:
+  CHANGELOG.md
+  README.md
+
+data-files:
+  bls12-381-test-vectors/test_vectors/bls_sig_aug_test_vectors
+  bls12-381-test-vectors/test_vectors/ec_operations_test_vectors
+  bls12-381-test-vectors/test_vectors/h2c_large_dst
+  bls12-381-test-vectors/test_vectors/pairing_test_vectors
+  bls12-381-test-vectors/test_vectors/serde_test_vectors
 
 flag secp256k1-support
-    description: Enable support for functions from libsecp256k1. Requires
-                 a recent libsecp256k1 with support for Schnorr signatures.
-    default: True
-    manual: True
+  description:
+    Enable support for functions from libsecp256k1. Requires
+    a recent libsecp256k1 with support for Schnorr signatures.
 
-common base                         { build-depends: base >= 4.14 && < 5 }
+  default: True
+  manual: True
+
+common base
+  build-depends: base >=4.14 && <5
 
 common project-config
-  default-language:     Haskell2010
-
-  ghc-options:          -Wall
-                        -Wcompat
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wpartial-fields
-                        -Wredundant-constraints
-                        -Wunused-packages
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
+    -Wunused-packages
 
 library
-  import:               base, project-config
-  hs-source-dirs:       src
+  import: base, project-config
+  hs-source-dirs: src
+  exposed-modules:
+    Bench.Crypto.BenchData
+    Bench.Crypto.DSIGN
+    Bench.Crypto.HASH
+    Bench.Crypto.KES
+    Bench.Crypto.VRF
+    Paths_cardano_crypto_tests
+    Test.Crypto.AllocLog
+    Test.Crypto.DSIGN
+    Test.Crypto.EllipticCurve
+    Test.Crypto.EqST
+    Test.Crypto.Hash
+    Test.Crypto.Instances
+    Test.Crypto.KES
+    Test.Crypto.Regressions
+    Test.Crypto.RunIO
+    Test.Crypto.Util
+    Test.Crypto.VRF
+    Test.Crypto.Vector.SerializationUtils
 
-  exposed-modules:      Test.Crypto.DSIGN
-                        Test.Crypto.EllipticCurve
-                        Test.Crypto.Hash
-                        Test.Crypto.RunIO
-                        Test.Crypto.KES
-                        Test.Crypto.Util
-                        Test.Crypto.AllocLog
-                        Test.Crypto.VRF
-                        Test.Crypto.Regressions
-                        Test.Crypto.Instances
-                        Test.Crypto.EqST
-                        Bench.Crypto.DSIGN
-                        Bench.Crypto.VRF
-                        Bench.Crypto.KES
-                        Bench.Crypto.HASH
-                        Bench.Crypto.BenchData
-                        Test.Crypto.Vector.SerializationUtils
-                        Paths_cardano_crypto_tests
-
-  build-depends:        base
-                      , bytestring >=0.10.12.0
-                      , cardano-binary
-                      , cardano-crypto-class ^>= 2.2
-                      , cardano-crypto-praos
-                      , cborg
-                      , containers
-                      , crypton
-                      , contra-tracer ==0.1.0.1
-                      , deepseq
-                      , formatting
-                      , io-classes >= 1.4.0
-                      , mempack
-                      , mtl
-                      , nothunks
-                      , pretty-show
-                      , QuickCheck
-                      , quickcheck-instances
-                      , tasty
-                      , tasty-hunit
-                      , tasty-quickcheck
-                      , tasty-hunit
-                      , criterion
-                      , base16-bytestring
-                      , tasty-hunit
-                      , vector
+  build-depends:
+    QuickCheck,
+    base,
+    base16-bytestring,
+    bytestring >=0.10.12.0,
+    cardano-binary,
+    cardano-crypto-class ^>=2.2,
+    cardano-crypto-praos,
+    cborg,
+    containers,
+    contra-tracer ==0.1.0.1,
+    criterion,
+    crypton,
+    deepseq,
+    formatting,
+    io-classes >=1.4.0,
+    mempack,
+    mtl,
+    nothunks,
+    pretty-show,
+    quickcheck-instances,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    vector,
 
   if flag(secp256k1-support)
     cpp-options: -DSECP256K1_ENABLED
-    exposed-modules: Test.Crypto.Vector.Secp256k1DSIGN
-                     Test.Crypto.Vector.StringConstants
-                     Test.Crypto.Vector.Vectors
+    exposed-modules:
+      Test.Crypto.Vector.Secp256k1DSIGN
+      Test.Crypto.Vector.StringConstants
+      Test.Crypto.Vector.Vectors
 
 test-suite test-crypto
-  import:               base, project-config
-  type:                 exitcode-stdio-1.0
-  hs-source-dirs:       test
-  main-is:              Main.hs
-  build-depends:        base
-                      , cardano-crypto-class
-                      , cardano-crypto-tests
-                      , tasty
-                      , tasty-quickcheck
+  import: base, project-config
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Main.hs
+  build-depends:
+    base,
+    cardano-crypto-class,
+    cardano-crypto-tests,
+    tasty,
+    tasty-quickcheck,
 
   if flag(secp256k1-support)
     cpp-options: -DSECP256K1_ENABLED
-
-  ghc-options:          -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
 
 benchmark bench-crypto
-  import:               base, project-config
-  type:                 exitcode-stdio-1.0
-  hs-source-dirs:       bench
-  main-is:              Main.hs
-  build-depends:        base
-                      , cardano-crypto-class
-                      , cardano-crypto-tests
-                      , criterion
+  import: base, project-config
+  type: exitcode-stdio-1.0
+  hs-source-dirs: bench
+  main-is: Main.hs
+  build-depends:
+    base,
+    cardano-crypto-class,
+    cardano-crypto-tests,
+    criterion,
 
-  ghc-options:          -threaded
+  ghc-options: -threaded

--- a/cardano-git-rev/cardano-git-rev.cabal
+++ b/cardano-git-rev/cardano-git-rev.cabal
@@ -1,40 +1,41 @@
 cabal-version: 3.0
+name: cardano-git-rev
+version: 0.2.2.0
+synopsis: Git revisioning
+description: Embeds git revision into Haskell packages.
+category:
+  Cardano,
+  Versioning,
 
-name:                   cardano-git-rev
-version:                0.2.2.0
-synopsis:               Git revisioning
-description:            Embeds git revision into Haskell packages.
-category:               Cardano,
-                        Versioning,
-copyright:              2022-2023 Input Output Global Inc (IOG).
-author:                 IOHK
-maintainer:             operations@iohk.io
-license:                Apache-2.0
-license-files:          LICENSE
-                        NOTICE
-build-type:             Simple
-extra-source-files:     README.md
+copyright: 2022-2023 Input Output Global Inc (IOG).
+author: IOHK
+maintainer: operations@iohk.io
+license: Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+build-type: Simple
+extra-source-files: README.md
 
 common project-config
-  default-language:     Haskell2010
-  build-depends:        base >= 4.14 && < 5
-
-  ghc-options:          -Wall
-                        -Wcompat
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wpartial-fields
-                        -Wredundant-constraints
-                        -Wunused-packages
+  default-language: Haskell2010
+  build-depends: base >=4.14 && <5
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
+    -Wunused-packages
 
 library
-  import:               project-config
-
-  hs-source-dirs:       src
-  c-sources:            cbits/rev.c
-
-  exposed-modules:      Cardano.Git.Rev
-
-  build-depends:        process
-                      , template-haskell
-                      , text
+  import: project-config
+  hs-source-dirs: src
+  c-sources: cbits/rev.c
+  exposed-modules: Cardano.Git.Rev
+  build-depends:
+    process,
+    template-haskell,
+    text,

--- a/cardano-slotting/cardano-slotting.cabal
+++ b/cardano-slotting/cardano-slotting.cabal
@@ -1,73 +1,82 @@
 cabal-version: 3.0
-
-name:                cardano-slotting
-version:             0.2.0.0
-synopsis:            Key slotting types for cardano libraries
-license:             Apache-2.0
+name: cardano-slotting
+version: 0.2.0.0
+synopsis: Key slotting types for cardano libraries
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-author:              IOHK Formal Methods Team
-maintainer:          formal.methods@iohk.io
-copyright:           IOHK
-build-type:          Simple
-extra-source-files:  CHANGELOG.md
 
-common base                         { build-depends: base >= 4.14 && < 5 }
+author: IOHK Formal Methods Team
+maintainer: formal.methods@iohk.io
+copyright: IOHK
+build-type: Simple
+extra-source-files: CHANGELOG.md
+
+common base
+  build-depends: base >=4.14 && <5
 
 common project-config
-  default-language:     Haskell2010
-  ghc-options:          -Wall
-                        -Wcompat
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wunused-packages
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
 
 library
-  import:               base, project-config
-  hs-source-dirs:       src
-
+  import: base, project-config
+  hs-source-dirs: src
   exposed-modules:
-                        Cardano.Slotting.Block
-                        Cardano.Slotting.EpochInfo
-                        Cardano.Slotting.EpochInfo.API
-                        Cardano.Slotting.EpochInfo.Extend
-                        Cardano.Slotting.EpochInfo.Impl
-                        Cardano.Slotting.Slot
-                        Cardano.Slotting.Time
+    Cardano.Slotting.Block
+    Cardano.Slotting.EpochInfo
+    Cardano.Slotting.EpochInfo.API
+    Cardano.Slotting.EpochInfo.Extend
+    Cardano.Slotting.EpochInfo.Impl
+    Cardano.Slotting.Slot
+    Cardano.Slotting.Time
 
-  build-depends:        aeson
-                      , base
-                      , cardano-binary
-                      , deepseq
-                      , mmorph
-                      , nothunks
-                      , quiet
-                      , serialise
-                      , time
+  build-depends:
+    aeson,
+    base,
+    cardano-binary,
+    deepseq,
+    mmorph,
+    nothunks,
+    quiet,
+    serialise,
+    time,
 
 library testlib
-  import:               base, project-config
-  visibility:           public
-  hs-source-dirs:       testlib
-  exposed-modules:      Test.Cardano.Slotting.Arbitrary
-                        Test.Cardano.Slotting.Numeric
-                        Test.Cardano.Slotting.TreeDiff
-  build-depends:        base
-                      , cardano-slotting
-                      , QuickCheck
-                      , tree-diff
+  import: base, project-config
+  visibility: public
+  hs-source-dirs: testlib
+  exposed-modules:
+    Test.Cardano.Slotting.Arbitrary
+    Test.Cardano.Slotting.Numeric
+    Test.Cardano.Slotting.TreeDiff
+
+  build-depends:
+    QuickCheck,
+    base,
+    cardano-slotting,
+    tree-diff,
 
 test-suite tests
-  import:               base, project-config
-  type:                 exitcode-stdio-1.0
-  hs-source-dirs:       test
-  main-is:              Main.hs
-  other-modules:      Test.Cardano.Slotting.EpochInfo
-  build-depends:        base
-                      , cardano-slotting
-                      , tasty
-                      , tasty-quickcheck
+  import: base, project-config
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Main.hs
+  other-modules: Test.Cardano.Slotting.EpochInfo
+  build-depends:
+    base,
+    cardano-slotting,
+    tasty,
+    tasty-quickcheck,
 
-  ghc-options:          -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N

--- a/cardano-strict-containers/cardano-strict-containers.cabal
+++ b/cardano-strict-containers/cardano-strict-containers.cabal
@@ -1,38 +1,42 @@
-cabal-version:       >=1.10
-
-name:                cardano-strict-containers
-version:             0.1.4.0
-synopsis:            Various strict container types
-license:             Apache-2.0
+cabal-version: >=1.10
+name: cardano-strict-containers
+version: 0.1.4.0
+synopsis: Various strict container types
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-extra-source-files:  CHANGELOG.md
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           IOHK
-build-type:          Simple
+
+extra-source-files: CHANGELOG.md
+author: IOHK
+maintainer: operations@iohk.io
+copyright: IOHK
+build-type: Simple
 
 library
-  default-language:     Haskell2010
-  hs-source-dirs:       src
+  default-language: Haskell2010
+  hs-source-dirs: src
   ghc-options:
     -Wall
     -Wcompat
     -Wincomplete-record-updates
     -Wincomplete-uni-patterns
     -Wredundant-constraints
-  exposed-modules:      Data.FingerTree.Strict
-                        Data.Maybe.Strict
-                        Data.Sequence.Strict
-                        Data.Unit.Strict
-  build-depends:        aeson
-                      , base
-                      , cardano-binary >= 1.6
-                      , cborg
-                      , containers
-                      , data-default-class
-                      , deepseq
-                      , fingertree
-                      , nothunks
-                      , serialise
+
+  exposed-modules:
+    Data.FingerTree.Strict
+    Data.Maybe.Strict
+    Data.Sequence.Strict
+    Data.Unit.Strict
+
+  build-depends:
+    aeson,
+    base,
+    cardano-binary >=1.6,
+    cborg,
+    containers,
+    data-default-class,
+    deepseq,
+    fingertree,
+    nothunks,
+    serialise

--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,7 @@
                 fourmolu = fourmoluVersion;
                 hlint = "3.8";
                 haskell-language-server = "2.9.0.0";
+                cabal-gild = "1.5.0.1";
               };
 
             # and from nixpkgs or other inputs

--- a/heapwords/heapwords.cabal
+++ b/heapwords/heapwords.cabal
@@ -1,21 +1,21 @@
-cabal-version:       >=1.10
-
-name:                heapwords
-version:             0.1.0.2
-synopsis:            Heapwords
-license:             Apache-2.0
+cabal-version: >=1.10
+name: heapwords
+version: 0.1.0.2
+synopsis: Heapwords
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           IOHK
-build-type:          Simple
-extra-source-files:  CHANGELOG.md
+
+author: IOHK
+maintainer: operations@iohk.io
+copyright: IOHK
+build-type: Simple
+extra-source-files: CHANGELOG.md
 
 library
-  default-language:     Haskell2010
-  hs-source-dirs:       src
+  default-language: Haskell2010
+  hs-source-dirs: src
   ghc-options:
     -Wall
     -Wcompat
@@ -24,17 +24,17 @@ library
     -Wredundant-constraints
     -Wunused-packages
 
-  exposed-modules:      Cardano.HeapWords
-  build-depends:        array
-                      , base
-                      , bytestring
-                      , containers
-                      , ghc-prim
-                      , text
-                      , time
-                      , vector
+  exposed-modules: Cardano.HeapWords
+  build-depends:
+    array,
+    base,
+    bytestring,
+    containers,
+    ghc-prim,
+    text,
+    time,
+    vector
 
-
-  if impl(ghc < 9.0.0)
+  if impl(ghc <9.0.0)
     build-depends:
       integer-gmp

--- a/measures/measures.cabal
+++ b/measures/measures.cabal
@@ -1,22 +1,21 @@
-cabal-version:       >=1.10
-
-name:                measures
-version:             0.1.0.2
-synopsis:            An abstraction for (tuples of) measured quantities
-license:             Apache-2.0
+cabal-version: >=1.10
+name: measures
+version: 0.1.0.2
+synopsis: An abstraction for (tuples of) measured quantities
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           IOHK
-build-type:          Simple
-extra-source-files:  CHANGELOG.md
+
+author: IOHK
+maintainer: operations@iohk.io
+copyright: IOHK
+build-type: Simple
+extra-source-files: CHANGELOG.md
 
 library
-  default-language:     Haskell2010
-  hs-source-dirs:       src
-
+  default-language: Haskell2010
+  hs-source-dirs: src
   ghc-options:
     -Wall
     -Wcompat
@@ -28,23 +27,23 @@ library
     -Wmissing-export-lists
 
   exposed-modules:
-                        Data.Measure
-                        Data.Measure.Class
+    Data.Measure
+    Data.Measure.Class
 
-  build-depends:        base
-                      , base-deriving-via
+  build-depends:
+    base,
+    base-deriving-via
 
 test-suite test
-  hs-source-dirs:       test
-  main-is:              Main.hs
-  type:                 exitcode-stdio-1.0
-
+  hs-source-dirs: test
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
   other-modules:
-                        Test.Data.Measure
+    Test.Data.Measure
 
-  build-depends:        base
-                      , QuickCheck
-                      , tasty
-                      , tasty-quickcheck
-
-                      , measures
+  build-depends:
+    QuickCheck,
+    base,
+    measures,
+    tasty,
+    tasty-quickcheck

--- a/orphans-deriving-via/orphans-deriving-via.cabal
+++ b/orphans-deriving-via/orphans-deriving-via.cabal
@@ -1,22 +1,21 @@
-cabal-version:       >=1.10
-
-name:                orphans-deriving-via
-version:             0.1.0.2
-synopsis:            Orphan instances for the base-deriving-via hooks
-license:             Apache-2.0
+cabal-version: >=1.10
+name: orphans-deriving-via
+version: 0.1.0.2
+synopsis: Orphan instances for the base-deriving-via hooks
+license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           IOHK
-build-type:          Simple
-extra-source-files:  CHANGELOG.md
+
+author: IOHK
+maintainer: operations@iohk.io
+copyright: IOHK
+build-type: Simple
+extra-source-files: CHANGELOG.md
 
 library
-  default-language:     Haskell2010
-  hs-source-dirs:       src
-
+  default-language: Haskell2010
+  hs-source-dirs: src
   ghc-options:
     -Wall
     -Wcompat
@@ -28,10 +27,11 @@ library
     -Wmissing-export-lists
 
   exposed-modules:
-                        Data.DerivingVia.DeepSeq
-                        Data.DerivingVia.NoThunks
+    Data.DerivingVia.DeepSeq
+    Data.DerivingVia.NoThunks
 
-  build-depends:        base
-                      , base-deriving-via
-                      , deepseq
-                      , nothunks
+  build-depends:
+    base,
+    base-deriving-via,
+    deepseq,
+    nothunks

--- a/scripts/cabal-format.sh
+++ b/scripts/cabal-format.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode="${1:-format}"
+
+if [[ "$mode" != "format" && "$mode" != "check" ]]; then
+  echo "Error: Invalid mode: ${mode}. Allowed values are 'format' or 'check'." >&2
+  exit 1
+fi
+
+git ls-files -- '*.cabal' 'cabal.project' | while IFS= read -r f; do
+  cmd=(cabal-gild -i "$f" -m "$mode")
+
+  if [[ "$mode" == "format" ]]; then
+    cmd+=(-o "$f")
+  fi
+
+  "${cmd[@]}"
+done
+
+if [[ "$mode" == "format" ]]; then
+  git diff --exit-code
+fi


### PR DESCRIPTION
# Description
 
*  Adds cabal-gild to nix develop
 * Adds a script that formats cabal and cabal.project files. 
 * Adds a cabal format check in github workflow


<!-- Add your description here, if this PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Commits that only contain large amounts of formatting changes were added to `.git-blame-ignore-revs`
- [ ] Self-reviewed the diff
