### PR TITLE
Pin Cabal version in Haddocks to GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: "9.2.8"
-        cabal-version: latest
+        cabal-version: "3.12"
 
     - name: Install system dependencies
       uses: input-output-hk/actions/base@latest

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,7 +39,21 @@ jobs:
     - name: Build haddocks
       run: scripts/haddocks.sh haddocks all
 
+    # Save generated output as an artifact
+    - name: Archive haddocks directory
+      run: tar -czf haddocks.tgz haddocks
+    - name: Upload haddocks artifact
+      # upload-artifact is pinned to avoid a bug in download-artifact
+      # See https://github.com/actions/download-artifact/issues/328
+      uses: actions/upload-artifact@v4.2.0
+      with:
+        name: haddocks
+        path: haddocks.tgz
+        overwrite: true
+        retention-days: 1
+
     - name: Add files
+      if: github.event_name == 'push' && github.ref_name == 'master'
       run: |
         git config --local user.name ${{ github.actor }}
         git config --local user.email "${{ github.actor }}@users.noreply.github.com"
@@ -75,6 +89,7 @@ jobs:
         git commit -qm "Updated from ${GITHUB_SHA} via ${GITHUB_EVENT_NAME}"
 
     - name: Push to gh-pages
+      if: github.event_name == 'push' && github.ref_name == 'master'
       uses: ad-m/github-push-action@v0.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This fixes an error, "haddocks/cardano-data:testlib/*.haddock: openBinaryFile: does not exist" in CI. See IntersectMBO/cardano-ledger#4840 and IntersectMBO/cardano-ledger#4845 for details.

When a fix has been developed in `cardano-ledger` that allows use of the latest `cabal`, it will be copied here.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
