### PR TITLE
change blsMSM interface & fix memory bug

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -1054,7 +1054,7 @@ blsMSM ssAndps = unsafePerformIO $ do
                     affineArrayPtr
                     numPoints'
                     scalarArrayPtr
-                    (fromIntegral @Int @CSize 255)
+                    (255 :: CSize)
                     (ScratchPtr scratchPtr)
 
 ---- PT operations

--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -1051,10 +1051,6 @@ blsMSM threshold ssAndps = unsafePerformIO $ do
                 numPoints' = fromIntegral numPoints
                 scratchSize :: Int
                 scratchSize = fromIntegral @CSize @Int $ c_blst_scratch_sizeof (Proxy @curve) numPoints'
-                -- Multiply by 8, because blst_mult_pippenger takes number of *bits*, but
-                -- sizeScalar is in *bytes*
-                nbits :: CSize
-                nbits = fromIntegral @Int @CSize $ sizeScalar * 8
             allocaBytes (numPoints * sizeAffine (Proxy @curve)) $ \affinesBlockPtr -> do
               c_blst_to_affines (AffineBlockPtr affinesBlockPtr) pointArrayPtr numPoints'
               withAffineBlockArrayPtr affinesBlockPtr numPoints $ \affineArrayPtr -> do
@@ -1064,7 +1060,7 @@ blsMSM threshold ssAndps = unsafePerformIO $ do
                     affineArrayPtr
                     numPoints'
                     scalarArrayPtr
-                    nbits
+                    (fromIntegral @Int @CSize 255)
                     (ScratchPtr scratchPtr)
 
 ---- PT operations

--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -998,8 +998,8 @@ scalarCanonical scalar =
 -- by means of a modulo operation over the 'scalarPeriod'.
 -- Negative numbers will also be brought to the range
 -- [0, 'scalarPeriod' - 1] via modular reduction.
-blsMSM :: forall curve. BLS curve => Int -> [(Integer, Point curve)] -> Point curve
-blsMSM threshold ssAndps = unsafePerformIO $ do
+blsMSM :: forall curve. BLS curve => [(Integer, Point curve)] -> Point curve
+blsMSM ssAndps = unsafePerformIO $ do
   zeroScalar <- scalarFromInteger 0
   filteredPoints <-
     foldrM
@@ -1035,12 +1035,6 @@ blsMSM threshold ssAndps = unsafePerformIO $ do
     [(scalar, pt)] -> do
       i <- scalarToInteger scalar
       return (blsMult pt i)
-    _ | length filteredPoints <= threshold -> do
-      return $
-        foldr
-          (\(scalar, pt) acc -> blsAddOrDouble acc (blsMult pt (unsafePerformIO $ scalarToInteger scalar)))
-          blsZero
-          filteredPoints
     _ -> do
       let (scalars, points) = unzip filteredPoints
 

--- a/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
@@ -27,7 +27,6 @@ import Test.QuickCheck (
   Property,
   choose,
   chooseAny,
-  classify,
   oneof,
   suchThatMap,
   (===),

--- a/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
@@ -137,10 +137,8 @@ testBLSCurve name _ =
         BLS.blsMult (BLS.blsAddOrDouble a b) c === BLS.blsAddOrDouble (BLS.blsMult a c) (BLS.blsMult b c)
     , testProperty "MSM matches naive approach" $ \(ssAndPs :: [(BigInteger, BLS.Point curve)]) ->
         let pairs = [(i, p) | (BigInteger i, p) <- ssAndPs]
-            threshold = 10
-         in classify (length pairs <= threshold) "Below threshold" $
-              BLS.blsMSM threshold pairs
-                === foldr (\(s, p) acc -> BLS.blsAddOrDouble acc (BLS.blsMult p s)) (BLS.blsZero @curve) pairs
+         in BLS.blsMSM pairs
+              === foldr (\(s, p) acc -> BLS.blsAddOrDouble acc (BLS.blsMult p s)) (BLS.blsZero @curve) pairs
     , testProperty "mult by zero is inf" $ \(a :: BLS.Point curve) ->
         BLS.blsIsInf (BLS.blsMult a 0)
     , testProperty "mult by -1 is equal to neg" $ \(a :: BLS.Point curve) ->


### PR DESCRIPTION
# Description

This PR introduces two changes, the first is a change to the interface of the blsMSM function. The second is a bug fix in the C call of `blst_{p1s/p2s}_mult_pippenger`.

## 1. A benchmark on the plutus machine
For the former change, benchmarking on the plutus machine has shown that the pippenger MSM approach is always faster than the naive approach. This can be deduced from these two tests (test [1](https://github.com/IntersectMBO/plutus/actions/runs/16025165385/job/45211195747) and test [2](https://github.com/IntersectMBO/plutus/actions/runs/16026799532/job/45216687147)). The first test had performed the naive method up to 10 points, and the second test performed the pippenger approach for inputs of all sizes. For G1 we can see in the first test that
```bash
benchmarking Bls12_381_G1_multiScalarMul/1/1
time                 79.45 μs   (79.45 μs .. 79.46 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 79.48 μs   (79.47 μs .. 79.49 μs)
std dev              30.99 ns   (25.29 ns .. 40.39 ns)

benchmarking Bls12_381_G1_multiScalarMul/2/2
time                 202.6 μs   (202.5 μs .. 202.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 202.8 μs   (202.8 μs .. 202.9 μs)
std dev              298.1 ns   (247.6 ns .. 375.6 ns)
```
while for the `threshold = 0` we have
```bash
benchmarking Bls12_381_G1_multiScalarMul/1/1
time                 79.73 μs   (79.62 μs .. 79.82 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 79.78 μs   (79.73 μs .. 79.83 μs)
std dev              178.1 ns   (163.6 ns .. 203.1 ns)

benchmarking Bls12_381_G1_multiScalarMul/2/2
time                 151.2 μs   (151.2 μs .. 151.3 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 151.2 μs   (151.2 μs .. 151.2 μs)
std dev              61.93 ns   (53.39 ns .. 77.26 ns)
```
We clearly see that the speed up of the pippenger algorithm already starts after one point and an integer. Similarly for G2,
```bash
benchmarking Bls12_381_G2_multiScalarMul/1/1
time                 162.8 μs   (162.8 μs .. 162.9 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 162.8 μs   (162.8 μs .. 162.9 μs)
std dev              81.15 ns   (64.75 ns .. 112.0 ns)

benchmarking Bls12_381_G2_multiScalarMul/2/2
time                 379.3 μs   (379.3 μs .. 379.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 379.4 μs   (379.3 μs .. 379.4 μs)
std dev              185.1 ns   (147.5 ns .. 266.3 ns)
```
and for `threshold = 0` we have
```bash
benchmarking Bls12_381_G2_multiScalarMul/1/1
time                 162.6 μs   (162.5 μs .. 162.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 162.6 μs   (162.6 μs .. 162.6 μs)
std dev              34.78 ns   (29.67 ns .. 41.29 ns)

benchmarking Bls12_381_G2_multiScalarMul/2/2
time                 357.3 μs   (357.2 μs .. 357.3 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 357.3 μs   (357.2 μs .. 357.3 μs)
std dev              121.3 ns   (99.69 ns .. 150.0 ns)
```
A similar result as for G1. Note that the other benchmarks (with more inputs) were strictly increasing, the conclusion thus also holds for the rest of the domain of list sizes.

## 2. A bug fix
While benchmarking, we caught a segmentation fault in [this](https://github.com/IntersectMBO/plutus/actions/runs/15847340555/job/44672458560#step:3:98) test. After further investigation we could reproduce the bug by setting the seed used in the RNG of Criterion. @kwxm extracted from it [this](https://gist.github.com/perturbing/441e3edda27018d8de8b006456b95493) test vector that reproduced the issue outside of criterion. To reproduce the seg fault yourself, run 
```bash
wget https://gist.githubusercontent.com/perturbing/441e3edda27018d8de8b006456b95493/raw/3a1411bdf2ab59a165f9c128ccbbe8fd37e55dcf/test-vector-msm-bug.uplc
nix run github:IntersectMBO/plutus/c5a0a685f4e88e4896bc768900bf152c8d455988#musl64-uplc -- evaluate -i test-vector-msm-bug.uplc
```
Using this test vector, we were able to identify that the bug has its origin in the passing of an incorrect `nbits` argument in the `blst_{p1s/p2s}_mult_pippenger` C call. Initially, we used the `sizeScalar * 8` for this, but this is wrong. As [other](https://docs.rs/blstrs/latest/src/blstrs/g1.rs.html#645) implementations do as well, the `nbits` here must be 255 bits. The conjecture now is that [this](https://github.com/supranational/blst/blob/8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355/src/multi_scalar.c#L366) modulo reduction will underestimate the tiling for some set of inputs (we saw the bug with lists of sizes 4 and 14). This wrong tiling under allocates memory as a result. When multiple of these C calls are made together, the chances of overlap between each in the memory layout increase. This is why, in the above test vector, at the end of its file, the lines
```
tail -3 test-vector-msm-bug.uplc
    (con integer 10000)
  ]
)
```
contain a large number. Another supporting test to run for the above is to run the failing test via valgrind
```bash
nix build github:IntersectMBO/plutus/c5a0a685f4e88e4896bc768900bf152c8d455988#musl64-uplc
valgrind --tool=memcheck -s --track-origins=yes result/bin/uplc evaluate -i test-vector-msm-bug.uplc
```
this will show that the 1 bytes memory violation happens in `get_wval_limb` [here](https://github.com/supranational/blst/blob/8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355/src/ec_mult.h#L23)
```bash
...
==366120== 1 errors in context 1 of 1:
==366120== Invalid read of size 1
==366120==    at 0x17D0A91: get_wval_limb (in /nix/store/p7cbzsj0v5khcpjiy2cfkydn3rk0h01s-plutus-executables-exe-uplc-x86_64-unknown-linux-musl-1.47.0.0/bin/uplc)
==366120==    by 0x17DDBC1: POINTonE1s_mult_wbits (in /nix/store/p7cbzsj0v5khcpjiy2cfkydn3rk0h01s-plutus-executables-exe-uplc-x86_64-unknown-linux-musl-1.47.0.0/bin/uplc)
==366120==    by 0x17E6FBE: blst_p1s_mult_pippenger (in /nix/store/p7cbzsj0v5khcpjiy2cfkydn3rk0h01s-plutus-executables-exe-uplc-x86_64-unknown-linux-musl-1.47.0.0/bin/uplc)
==366120==    by 0x75F308: cardanozmcryptozmclasszm2zi2zi3zi0zm1FJyp8AKbQACwl5cOZZrbGM_CardanoziCryptoziEllipticCurveziBLS12zu381ziInternal_czublstzup1szumultzupippenger_info (in /nix/store/p7cbzsj0v5khcpjiy2cfkydn3rk0h01s-plutus-executables-exe-uplc-x86_64-unknown-linux-musl-1.47.0.0/bin/uplc)
==366120==  Address 0x4200c00000 is in a --- anonymous segment
...
```
To see the fix in action, you can run
```bash
nix run github:IntersectMBO/plutus/fbcaf4d2a7b9336ef64ee8fabcd1ab717aedb760#musl64-uplc -- evaluate -i test-vector-msm-bug.uplc
```

## 3. An extra check
There is one other place in the code where `sizeScalar * 8` is used, where it might also be misused. This is in the `c_blst_mult` function call [here](https://github.com/IntersectMBO/cardano-base/blob/5b2244205b17b99196172684584778e3fec69ed7/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs#L819C9-L819C20). Similarly as before, the rust bindings use 255 bits [here](https://docs.rs/blstrs/latest/src/blstrs/g1.rs.html#578) as well. And a quick check of the c code shows that for both [G1](https://github.com/supranational/blst/blob/6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c/src/e1.c#L513) and [G2](https://github.com/supranational/blst/blob/6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c/src/e2.c#L587), the code is safe, even if we pass 256 bits.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
