### PR TITLE
Added `filter` function to `Data.Sequence.Strict`

### DIFF
--- a/cardano-strict-containers/CHANGELOG.md
+++ b/cardano-strict-containers/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog for `cardano-strict-containers`
 
-# 0.1.4.1
+# 0.1.5.0
 
-*
+* Added `filter` function to `Data.Sequence.Strict`
 
 # 0.1.4.0
 

--- a/cardano-strict-containers/src/Data/Sequence/Strict.hs
+++ b/cardano-strict-containers/src/Data/Sequence/Strict.hs
@@ -62,6 +62,7 @@ module Data.Sequence.Strict (
   zipWith,
   unzip,
   unzipWith,
+  filter,
 )
 where
 
@@ -79,6 +80,7 @@ import qualified GHC.Exts as GHC (IsList (..))
 import NoThunks.Class (NoThunks (..), noThunksInValues)
 import Prelude hiding (
   drop,
+  filter,
   length,
   lookup,
   null,
@@ -372,6 +374,15 @@ findIndicesL p (StrictSeq xs) = Seq.findIndicesL p xs
 -- descending order.
 findIndicesR :: (a -> Bool) -> StrictSeq a -> [Int]
 findIndicesR p (StrictSeq xs) = Seq.findIndicesR p xs
+
+{-------------------------------------------------------------------------------
+  Filtering
+-------------------------------------------------------------------------------}
+
+-- | @'filter' p xs@ returns a sequence of those elements of @xs@ which satisfy
+-- the predicate @p@.
+filter :: (a -> Bool) -> StrictSeq a -> StrictSeq a
+filter p (StrictSeq xs) = StrictSeq $ Seq.filter p xs
 
 {-------------------------------------------------------------------------------
   Zips and Unzips


### PR DESCRIPTION
# Description

This PR adds the `filter` function that operates on `StrictSeq`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Self-reviewed the diff
