### PR TITLE
Guard against incorrect blst/libsodium usage with Template Haskell build-time checks

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -98,6 +98,8 @@ library
     Cardano.Crypto.VRF.NeverUsed
     Cardano.Crypto.VRF.Simple
     Cardano.Foreign
+    Cardano.ForeignChecks
+    Cardano.ForeignChecks.TH
 
   other-modules:
     Cardano.Crypto.PackedBytes
@@ -119,6 +121,7 @@ library
     mtl,
     nothunks,
     primitive >=0.8,
+    process,
     serialise,
     template-haskell,
     text,

--- a/cardano-crypto-class/src/Cardano/ForeignChecks.hs
+++ b/cardano-crypto-class/src/Cardano/ForeignChecks.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Cardano.ForeignChecks () where
+
+import Cardano.ForeignChecks.TH (
+  ensureExactVersion,
+  ensureExactVersionOrCommit,
+ )
+
+-- libsodium == 1.0.18
+$(ensureExactVersion "libsodium" (1, 0, 18))
+
+-- libblst == 0.3.14 OR libblst == "commit hash"
+-- see: https://github.com/input-output-hk/iohk-nix/blob/64ca6f4c0c6db283e2ec457c775bce75173fb319/overlays/crypto/libblst.nix#L44
+-- and: https://github.com/input-output-hk/iohk-nix/blob/64ca6f4c0c6db283e2ec457c775bce75173fb319/flake.nix#L15
+-- and: https://github.com/supranational/blst/commit/8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355
+$(ensureExactVersionOrCommit "libblst" (Just (0, 3, 14)) ["8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355"])

--- a/cardano-crypto-class/src/Cardano/ForeignChecks.hs
+++ b/cardano-crypto-class/src/Cardano/ForeignChecks.hs
@@ -7,8 +7,8 @@ import Cardano.ForeignChecks.TH (
   ensureExactVersionOrCommit,
  )
 
--- libsodium == 1.0.18
-$(ensureExactVersion "libsodium" (1, 0, 18))
+-- libsodium == 1.0.20
+$(ensureExactVersion "libsodium" (1, 0, 20))
 
 -- libblst == 0.3.14 OR libblst == "commit hash"
 -- see: https://github.com/input-output-hk/iohk-nix/blob/64ca6f4c0c6db283e2ec457c775bce75173fb319/overlays/crypto/libblst.nix#L44

--- a/cardano-crypto-class/src/Cardano/ForeignChecks.hs
+++ b/cardano-crypto-class/src/Cardano/ForeignChecks.hs
@@ -14,4 +14,11 @@ $(ensureExactVersion "libsodium" (1, 0, 18))
 -- see: https://github.com/input-output-hk/iohk-nix/blob/64ca6f4c0c6db283e2ec457c775bce75173fb319/overlays/crypto/libblst.nix#L44
 -- and: https://github.com/input-output-hk/iohk-nix/blob/64ca6f4c0c6db283e2ec457c775bce75173fb319/flake.nix#L15
 -- and: https://github.com/supranational/blst/commit/8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355
-$(ensureExactVersionOrCommit "libblst" (Just (0, 3, 14)) ["8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355"])
+$( ensureExactVersionOrCommit
+     "libblst"
+     (Just (0, 3, 14))
+     [ "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355"
+     , "03b5124029979755c752eec45f3c29674b558446"
+     , "3dd0f804b1819e5d03fb22ca2e6fac105932043a"
+     ]
+ )

--- a/cardano-crypto-class/src/Cardano/ForeignChecks/TH.hs
+++ b/cardano-crypto-class/src/Cardano/ForeignChecks/TH.hs
@@ -1,0 +1,83 @@
+module Cardano.ForeignChecks.TH (
+  ensureExactVersion,
+  ensureExactVersionOrCommit,
+) where
+
+import Control.Exception (SomeException, try)
+import Control.Monad (unless)
+import Data.Char (isDigit, isSpace)
+import Data.List (dropWhileEnd, intercalate, isPrefixOf)
+import Data.Maybe (fromMaybe)
+import Language.Haskell.TH
+import System.Process (readProcess)
+import Text.Read (readMaybe)
+
+-- | Trim leading/trailing whitespace (readProcess usually leaves a trailing '\n').
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace
+
+getModVersion :: String -> IO (Either String String)
+getModVersion pkg = do
+  r <- try (readProcess "pkg-config" ["--modversion", pkg] "") :: IO (Either SomeException String)
+  case r of
+    Left e -> pure (Left ("could not run pkg-config for " ++ pkg ++ ": " ++ show e))
+    Right v -> pure (Right (trim v))
+
+ensure :: String -> (String -> Bool) -> String -> Q [Dec]
+ensure pkg ok requirement = do
+  mv <- runIO (getModVersion pkg)
+  case mv of
+    Left err -> fail err
+    Right v -> do
+      unless (ok v) $
+        fail (pkg ++ " version/commit '" ++ v ++ "' does not satisfy " ++ requirement)
+      pure []
+
+-- | Split a string on '.' into components.
+splitOnDot :: String -> [String]
+splitOnDot [] = []
+splitOnDot s =
+  let (h, t) = break (== '.') s
+   in h : case t of
+        [] -> []
+        (_ : xs) -> splitOnDot xs
+
+-- | Parse "A.B.C" into a triple, defaulting missing/garbage parts to 0.
+parseTriple :: String -> (Int, Int, Int)
+parseTriple s =
+  let toNum t = fromMaybe 0 (readMaybe (takeWhile isDigit t) :: Maybe Int)
+   in case splitOnDot s of
+        (a : b : c : _) -> (toNum a, toNum b, toNum c)
+        (a : b : _) -> (toNum a, toNum b, 0)
+        (a : _) -> (toNum a, 0, 0)
+        _ -> (0, 0, 0)
+
+-- | Pretty-print a triple as "A.B.C".
+prettyT :: (Int, Int, Int) -> String
+prettyT (a, b, c) = intercalate "." (map show [a, b, c])
+
+ensureExactVersion :: String -> (Int, Int, Int) -> Q [Dec]
+ensureExactVersion pkg exactT =
+  let req = "== " ++ prettyT exactT
+   in ensure pkg (\v -> parseTriple v == exactT) req
+
+-- | True if any approved commit hash has a prefix v.
+commitAllowed :: [String] -> String -> Bool
+commitAllowed commits v = any (v `isPrefixOf`) commits
+
+-- | Accept either an exact version or an approved commit hash.
+ensureExactVersionOrCommit ::
+  -- | pkg-config package
+  String ->
+  -- | exact required version
+  Maybe (Int, Int, Int) ->
+  -- | approved commit hashes (prefix match)
+  [String] ->
+  Q [Dec]
+ensureExactVersionOrCommit pkg exact commits =
+  let versionOK v = maybe False (\e -> parseTriple v == e) exact
+      ok v = commitAllowed commits v || versionOK v
+      requirement = case exact of
+        Just e -> "== " ++ prettyT e ++ " OR one of commits " ++ show commits
+        Nothing -> "one of commits " ++ show commits
+   in ensure pkg ok requirement


### PR DESCRIPTION
This PR adds a small TH utility to enforce crypto dependency versions at compile time:

- libsodium must be 1.0.18.

- libblst must be 0.3.14 or the approved upstream commit 8c7db7f… (prefix match).

- The checks run via pkg-config --modversion and will fail the build with a clear message if the requirement isn’t met.