### PR TITLE
add cabal package bound on pkg-config lib blst

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.3.1
 
-*
+* Add package bound on pkg-config lib blst in #544
 
 ## 2.2.3.0
 

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -130,7 +130,7 @@ library
     build-depends:
       integer-gmp
   pkgconfig-depends:
-    libblst,
+    libblst >=0.1.14,
     libsodium,
 
   c-sources: cbits/blst_util.c

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -130,7 +130,7 @@ library
     build-depends:
       integer-gmp
   pkgconfig-depends:
-    libblst >=0.1.14,
+    libblst >=0.3.14,
     libsodium,
 
   c-sources: cbits/blst_util.c

--- a/flake.lock
+++ b/flake.lock
@@ -572,11 +572,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1745582862,
-        "narHash": "sha256-dMoJ6yHcRvUcB66nofzfAtmVxnDg8oPW3wiVtimXT/o=",
+        "lastModified": 1757407040,
+        "narHash": "sha256-rSHOQli+iffMmneSF/Ov8Uci6APaROWen+EfRb5mmiU=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5c16fdfc45deda7a4ccf964b6dfa1c3cab72f1f7",
+        "rev": "a94259528eb6d37073512d1767f14fd8ea12a8f0",
         "type": "github"
       },
       "original": {
@@ -604,16 +604,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "lastModified": 1751071626,
+        "narHash": "sha256-/uHE/AD2qGq4QLigWAnBHiVvpVXB04XAfrOtw8JMv+Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "rev": "a47938d89bdf8e279ad432bd6a473cf4c430f48c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-22.11",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
# Description
This PR introduces a version bound for `blst` (`>=0.3.14`). This is introduced for stronger guarantees on what version of `blst` we rely on when building and testing our software. 

Note that recently with [this](https://github.com/input-output-hk/iohk-nix/releases/tag/v3.1) release, the CI was updated to link `blst` with its correct numbered versioning (which was tested [here](https://github.com/IntersectMBO/cardano-base/pull/552) and [here](https://github.com/IntersectMBO/cardano-base/pull/545#issuecomment-3346719357)). Note that in the tests, the Hydra CI never failed to report a build failure for an incorrect bound on `blst`. This is why the flake lock for `iohk-nix` is also updated in this PR. So that we use
```bash
[thomas@extreme:/tmp/cardano-base]$ pkg-config --cflags --libs libblst
-I/nix/store/rx147mrlzx7m905wyngvlr70jb1bwirj-blst-0.3.14/include -L/nix/store/rx147mrlzx7m905wyngvlr70jb1bwirj-blst-0.3.14/lib -lblst

[thomas@extreme:/tmp/cardano-base]$ cat /nix/store/rx147mrlzx7m905wyngvlr70jb1bwirj-blst-0.3.14/lib/pkgconfig/libblst.pc 
prefix=/nix/store/rx147mrlzx7m905wyngvlr70jb1bwirj-blst-0.3.14
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: libblst
Description: Multilingual BLS12-381 signature library
URL: https://github.com/supranational/blst
Version: 0.3.14

Cflags: -I${includedir}
Libs: -L${libdir} -lblst
Libs.private:

```
instead of the old

```bash
[thomas@extreme:/tmp/cardano-base]$ pkg-config --cflags --libs libblst
-I/nix/store/hyrqcn18vbk2g4cz557r2c3idljgxwim-blst-8c7db7f/include -L/nix/store/hyrqcn18vbk2g4cz557r2c3idljgxwim-blst-8c7db7f/lib -lblst

[thomas@extreme:/tmp/cardano-base]$ cat /nix/store/hyrqcn18vbk2g4cz557r2c3idljgxwim-blst-8c7db7f/lib/pkgconfig/libblst.pc 
prefix=/nix/store/hyrqcn18vbk2g4cz557r2c3idljgxwim-blst-8c7db7f
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: libblst
Description: Multilingual BLS12-381 signature library
URL: https://github.com/supranational/blst
Version: 8c7db7f

Cflags: -I${includedir}
Libs: -L${libdir} -lblst
Libs.private:

```

Currently we build with version `v0.3.14` as per [this](https://github.com/input-output-hk/iohk-nix/blob/a94259528eb6d37073512d1767f14fd8ea12a8f0/flake.nix#L15). But note that in the future we might need to upgrade to newer versions, which have breaking changes (necessitating this bound check further).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff