### PR TITLE
Fix "Haddocks to GitHub Pages" workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       uses: input-output-hk/setup-haskell@v1
       id: setup-haskell
       with:
-        ghc-version: "9.2.8"
+        ghc-version: "9.6.7"
         cabal-version: "3.12"
 
     - name: Install system dependencies

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -29,6 +29,9 @@ CABAL_OPTS=(
 
 # Generate  `doc-index.json` and `doc-index.html` per package, to assemble them later at the top level.
 HADDOCK_OPTS=(
+  --haddock-executables
+  --haddock-tests
+  --haddock-benchmarks
   --haddock-html
   --haddock-hyperlink-source
   --haddock-option "--use-unicode"


### PR DESCRIPTION
# Description

The workflow has been broken since June, mostly because we dropped support for ghc versions less than 9.6 and the workflow was using 9.2.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
